### PR TITLE
Change `to_string` to `to_owned` when it just creates a `String` from a `&str`

### DIFF
--- a/src/changes.rs
+++ b/src/changes.rs
@@ -153,8 +153,8 @@ impl<'a> ChangeSet<'a> {
                 // Do a little dance to make writing safer - write to a temp file
                 // rename the original to a .bk, then rename the temp file to the
                 // original.
-                let tmp_name = filename.to_string() + ".tmp";
-                let bk_name = filename.to_string() + ".bk";
+                let tmp_name = filename.to_owned() + ".tmp";
+                let bk_name = filename.to_owned() + ".bk";
                 {
                     // Write text to temp file
                     let mut tmp_file = try!(File::create(&tmp_name));
@@ -165,7 +165,7 @@ impl<'a> ChangeSet<'a> {
                 try!(::std::fs::rename(tmp_name, filename));
             }
             WriteMode::NewFile(extn) => {
-                let filename = filename.to_string() + "." + extn;
+                let filename = filename.to_owned() + "." + extn;
                 let mut file = try!(File::create(&filename));
                 try!(write!(file, "{}", text));
             }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -154,7 +154,7 @@ impl<'a> FmtVisitor<'a> {
                         &None => String::new(),
                     };
                     let mut_str = match m {
-                        &ast::Mutability::MutMutable => "mut ".to_string(),
+                        &ast::Mutability::MutMutable => "mut ".to_owned(),
                         &ast::Mutability::MutImmutable => String::new(),
                     };
                     arg_item_strs[0] = format!("&{}{}self", lt_str, mut_str);
@@ -164,7 +164,7 @@ impl<'a> FmtVisitor<'a> {
                     arg_item_strs[0] = format!("self: {}", pprust::ty_to_string(ty));
                 }
                 ast::ExplicitSelf_::SelfValue(_) => {
-                    arg_item_strs[0] = "self".to_string();
+                    arg_item_strs[0] = "self".to_owned();
                     min_args = 2;
                 }
                 _ => {}
@@ -174,7 +174,7 @@ impl<'a> FmtVisitor<'a> {
         // Comments between args
         let mut arg_comments = Vec::new();
         if min_args == 2 {
-            arg_comments.push("".to_string());
+            arg_comments.push("".to_owned());
         }
         // TODO if there are no args, there might still be a comment, but without
         // spans for the comment or parens, there is no chance of getting it right.
@@ -239,7 +239,7 @@ impl<'a> FmtVisitor<'a> {
             } else if snippet.ends_with(separator) {
                 snippet = snippet[..snippet.len()-separator.len()].trim_matches(white_space);
             }
-            result.push(snippet.to_string());
+            result.push(snippet.to_owned());
             prev_end = get_hi(&item);
         }
         // Get the last commment.
@@ -254,7 +254,7 @@ impl<'a> FmtVisitor<'a> {
         let snippet = &snippet[..snippet.find(terminator)
                                     .unwrap_or(snippet.find(separator).unwrap_or(snippet.len()))];
         let snippet = snippet.trim();
-        result.push(snippet.to_string());
+        result.push(snippet.to_owned());
 
         result
     }
@@ -422,8 +422,8 @@ impl<'a> FmtVisitor<'a> {
     fn rewrite_return(&self, ret: &ast::FunctionRetTy) -> String {
         match *ret {
             ast::FunctionRetTy::DefaultReturn(_) => String::new(),
-            ast::FunctionRetTy::NoReturn(_) => "-> !".to_string(),
-            ast::FunctionRetTy::Return(ref ty) => "-> ".to_string() + &pprust::ty_to_string(ty),
+            ast::FunctionRetTy::NoReturn(_) => "-> !".to_owned(),
+            ast::FunctionRetTy::Return(ref ty) => "-> ".to_owned() + &pprust::ty_to_string(ty),
         }
     }
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -70,7 +70,7 @@ impl<'a> FmtVisitor<'a> {
                 false
             }
         ) {
-            Some(("self".to_string(), String::new()))
+            Some(("self".to_owned(), String::new()))
         } else {
             None
         };

--- a/src/mod.rs
+++ b/src/mod.rs
@@ -305,12 +305,12 @@ mod test {
             let path = entry.unwrap().path();
             let file_name = path.to_str().unwrap();
             println!("Testing '{}'...", file_name);
-            run(vec!["rustfmt".to_string(), file_name.to_string()], WriteMode::Return(HANDLE_RESULT));
+            run(vec!["rustfmt".to_owned(), file_name.to_owned()], WriteMode::Return(HANDLE_RESULT));
             count += 1;
         }
         // And also dogfood ourselves!
         println!("Testing 'src/mod.rs'...");
-        run(vec!["rustfmt".to_string(), "src/mod.rs".to_string()], WriteMode::Return(HANDLE_RESULT));
+        run(vec!["rustfmt".to_owned(), "src/mod.rs".to_owned()], WriteMode::Return(HANDLE_RESULT));
         count += 1;
 
         // Display results

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -223,7 +223,7 @@ impl<'a> FmtVisitor<'a> {
                 println!("Couldn't make snippet for span {:?}->{:?}",
                          self.codemap.lookup_char_pos(span.lo),
                          self.codemap.lookup_char_pos(span.hi));
-                "".to_string()
+                "".to_owned()
             }
         }
     }


### PR DESCRIPTION
This means that it doesn't have to go through the formatting hierarchy and can
just immediately reserve enough memory.