### PR TITLE
Add `Cargo.lock` file, because this application is a program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,12 @@
+[root]
+name = "rustfmt"
+version = "0.0.1"
+dependencies = [
+ "strings 0.0.1 (git+https://github.com/nrc/strings.rs.git)",
+]
+
+[[package]]
+name = "strings"
+version = "0.0.1"
+source = "git+https://github.com/nrc/strings.rs.git#551331d01911b7e8da056a4a019eb367cfaf03bd"
+


### PR DESCRIPTION
Do this so you can reliably build `rustfmt` in the future, even if one of the
dependencies (in this case, only `strings.rs`) makes backward-incompatible
changes.

See also http://doc.crates.io/guide.html#cargo.toml-vs-cargo.lock.