### PR TITLE
turn rustfmt into a lib, but still generate a binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,3 @@ license = "Apache-2.0/MIT"
 [dependencies.strings]
 strings = "0.0.1"
 git = "https://github.com/nrc/strings.rs.git"
-
-[[bin]]
-name = "rustfmt"
-path = "src/mod.rs"

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -1,0 +1,42 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(exit_status)]
+
+extern crate rustfmt;
+
+use rustfmt::format;
+
+fn main() {
+    let args: Vec<_> = std::env::args().collect();
+    //run(args, WriteMode::Display);
+    format(args);
+    std::env::set_exit_status(0);
+
+    // TODO unit tests
+    // let fmt = ListFormatting {
+    //     tactic: ListTactic::Horizontal,
+    //     separator: ",",
+    //     trailing_separator: SeparatorTactic::Vertical,
+    //     indent: 2,
+    //     h_width: 80,
+    //     v_width: 100,
+    // };
+    // let inputs = vec![(format!("foo"), String::new()),
+    //                   (format!("foo"), String::new()),
+    //                   (format!("foo"), String::new()),
+    //                   (format!("foo"), String::new()),
+    //                   (format!("foo"), String::new()),
+    //                   (format!("foo"), String::new()),
+    //                   (format!("foo"), String::new()),
+    //                   (format!("foo"), String::new())];
+    // let s = write_list(&inputs, &fmt);
+    // println!("  {}", s);
+}

--- a/tests/idem.rs
+++ b/tests/idem.rs
@@ -21,14 +21,20 @@ extern crate rustfmt;
 fn idempotent_tests() {
     println!("Idempotent tests:");
 
-    // Get all files in the tests/idem directory
-    let files = fs::read_dir("tests/idem").unwrap();
-    // For each file, run rustfmt and collect the output
     let mut count = 0;
     let mut fails = 0;
-    for entry in files {
+
+    // Get all files in the tests directory
+    let files = fs::read_dir("tests/idem").unwrap();
+    let files2 = fs::read_dir("tests").unwrap();
+    let files3 = fs::read_dir("src/bin").unwrap();
+    // For each file, run rustfmt and collect the output
+    for entry in files2.chain(files).chain(files3) {
         let path = entry.unwrap().path();
         let file_name = path.to_str().unwrap();
+        if !file_name.ends_with(".rs") {
+            continue;
+        }
         println!("Testing '{}'...", file_name);
         match idempotent_check(vec!["rustfmt".to_owned(), file_name.to_owned()]) {
             Ok(()) => {},
@@ -39,7 +45,7 @@ fn idempotent_tests() {
         }
         count += 1;
     }
-    // And also dogfood ourselves!
+    // And also dogfood rustfmt!
     println!("Testing 'src/lib.rs'...");
     match idempotent_check(vec!["rustfmt".to_owned(), "src/lib.rs".to_owned()]) {
         Ok(()) => {},


### PR DESCRIPTION
makes #44 unnecessary

the binary simply uses the rustfmt lib

tests are not in the source anymore, but as an extra test file.

Also, some of the atomic counter stuff is gone.

I hope I didn't break any behavior, but it runs through on my machine