### PR TITLE
Format required methods on traits

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![cfg(not(test))]
 #![feature(exit_status)]
 
 extern crate rustfmt;

--- a/tests/idem/trait.rs
+++ b/tests/idem/trait.rs
@@ -1,0 +1,20 @@
+// Test traits
+
+trait Foo {
+    fn bar(x: i32) -> Baz<U> {
+        Baz::new()
+    }
+
+    fn baz(a: AAAAAAAAAAAAAAAAAAAAAA, b: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB) -> RetType;
+
+    fn foo(a: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, // Another comment
+           b: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB)
+           -> RetType; // Some comment
+
+    fn baz(&mut self) -> i32;
+
+    fn increment(&mut self, x: i32);
+
+    fn read(&mut self, x: BufReader<R> /* Used to be MemReader */)
+        where R: Read;
+}


### PR DESCRIPTION
This should close https://github.com/nrc/rustfmt/issues/15. The main problem is that `rewrite_fn` and `rewrite_required_method` share a lot of code. I haven't found the ideal way to reduce this duplication. Any feedback would be greatly appreciated!