### PR TITLE
Show diffs for failing tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,8 +2,14 @@
 name = "rustfmt"
 version = "0.0.1"
 dependencies = [
+ "diff 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strings 0.0.1 (git+https://github.com/nrc/strings.rs.git)",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strings"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ license = "Apache-2.0/MIT"
 [dependencies.strings]
 strings = "0.0.1"
 git = "https://github.com/nrc/strings.rs.git"
+
+[dev-dependencies]
+diff = "0.1.0"


### PR DESCRIPTION
Adds diffs between expected output and actual output for failings tests. Shows return character to quickly identify trailing whitespace.

![diff](https://cloud.githubusercontent.com/assets/1255413/7451092/c20ba42c-f24c-11e4-8a5b-d67120e17214.png)

Closes https://github.com/nrc/rustfmt/issues/66.