### PR TITLE
Add reformating for parentheses

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -132,11 +132,14 @@ impl<'a> FmtVisitor<'a> {
         debug!("rewrite_paren, subexpr_str: `{}`", subexpr_str);
         let mut lines = subexpr_str.rsplit('\n');
         let last_line_len = lines.next().unwrap().len();
-        let last_line_offset = if lines.next().is_none() {offset+1} else {0};
+        let last_line_offset = match lines.next() {
+            None => offset+1,
+            Some(_) => 0,
+        };
         if width + offset - last_line_offset - last_line_len > 0 {
             format!("({})", subexpr_str)
         } else {
-            // FIXME That's correct unless we have width < 2. Return an Optrion for such cases ?
+            // FIXME That's correct unless we have width < 2. Return an Option for such cases ?
             format!("({}\n{} )", subexpr_str, make_indent(offset))
         }
     }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -125,6 +125,23 @@ impl<'a> FmtVisitor<'a> {
         format!("{}({})", callee_str, args_str)
     }
 
+    fn rewrite_paren(&mut self, subexpr: &ast::Expr, width: usize, offset: usize) -> String {
+        debug!("rewrite_paren, width: {}, offset: {}", width, offset);
+        // 1 is for opening paren
+        let subexpr_str = self.rewrite_expr(subexpr, width-1, offset+1);
+        debug!("rewrite_paren, subexpr_str: `{}`", subexpr_str);
+        let mut lines = subexpr_str.rsplit('\n');
+        let last_line_len = lines.next().unwrap().len();
+        let last_line_offset = if lines.next().is_none() {offset+1} else {0};
+        if width + offset - last_line_offset - last_line_len > 0 {
+            format!("({})", subexpr_str)
+        } else {
+            // FIXME That's correct unless we have width < 2. Return an Optrion for such cases ?
+            format!("({}\n{} )", subexpr_str, make_indent(offset))
+        }
+    }
+
+
     pub fn rewrite_expr(&mut self, expr: &ast::Expr, width: usize, offset: usize) -> String {
         match expr.node {
             ast::Expr_::ExprLit(ref l) => {
@@ -139,6 +156,9 @@ impl<'a> FmtVisitor<'a> {
             }
             ast::Expr_::ExprCall(ref callee, ref args) => {
                 return self.rewrite_call(callee, args, width, offset);
+            }
+            ast::Expr_::ExprParen(ref subexpr) => {
+                return self.rewrite_paren(subexpr, width, offset);
             }
             _ => {}
         }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -127,23 +127,12 @@ impl<'a> FmtVisitor<'a> {
 
     fn rewrite_paren(&mut self, subexpr: &ast::Expr, width: usize, offset: usize) -> String {
         debug!("rewrite_paren, width: {}, offset: {}", width, offset);
-        // 1 is for opening paren
-        let subexpr_str = self.rewrite_expr(subexpr, width-1, offset+1);
+        // 1 is for opening paren, 2 is for opening+closing, we want to keep the closing
+        // paren on the same line as the subexpr
+        let subexpr_str = self.rewrite_expr(subexpr, width-2, offset+1);
         debug!("rewrite_paren, subexpr_str: `{}`", subexpr_str);
-        let mut lines = subexpr_str.rsplit('\n');
-        let last_line_len = lines.next().unwrap().len();
-        let last_line_offset = match lines.next() {
-            None => offset+1,
-            Some(_) => 0,
-        };
-        if width + offset - last_line_offset - last_line_len > 0 {
-            format!("({})", subexpr_str)
-        } else {
-            // FIXME That's correct unless we have width < 2. Return an Option for such cases ?
-            format!("({}\n{} )", subexpr_str, make_indent(offset))
-        }
+        format!("({})", subexpr_str)
     }
-
 
     pub fn rewrite_expr(&mut self, expr: &ast::Expr, width: usize, offset: usize) -> String {
         match expr.node {

--- a/tests/idem/paren.rs
+++ b/tests/idem/paren.rs
@@ -1,0 +1,16 @@
+// Test parenthesis
+
+fn foo() {
+    let very_long_variable_name = (a + first + simple + test);
+    let very_long_variable_name = (write + something + here + to + fill + the + line + 12 + 34 + 567
+                                   );
+    let very_long_variable_name = (write + something + here + to + fill + the + line + 12 + 34 + 567
+                                   + 78);
+    let very_long_variable_name = (write + something + here + to + fill + the + line + 12 + 34 + 567
+                                   + 78 + fill + another + line + AAAA + BBBBBBB + CCCCCCCCCCCCCCCCC
+                                   );
+    let very_long_variable_name = (write + something + here + to + fill + the + line + 12 + 34 + 567
+                                   + 78 + fill + another + line + AAAA + BBBBBBB + CCCCCCCCCCCCCCC +
+                                   DDDDDDD + EEEEEE);
+
+}

--- a/tests/idem/paren.rs
+++ b/tests/idem/paren.rs
@@ -2,15 +2,6 @@
 
 fn foo() {
     let very_long_variable_name = (a + first + simple + test);
-    let very_long_variable_name = (write + something + here + to + fill + the + line + 12 + 34 + 567
-                                   );
-    let very_long_variable_name = (write + something + here + to + fill + the + line + 12 + 34 + 567
-                                   + 78);
-    let very_long_variable_name = (write + something + here + to + fill + the + line + 12 + 34 + 567
-                                   + 78 + fill + another + line + AAAA + BBBBBBB + CCCCCCCCCCCCCCCCC
-                                   );
-    let very_long_variable_name = (write + something + here + to + fill + the + line + 12 + 34 + 567
-                                   + 78 + fill + another + line + AAAA + BBBBBBB + CCCCCCCCCCCCCCC +
-                                   DDDDDDD + EEEEEE);
-
+    let very_long_variable_name = (a + first + simple + test + AAAAAAAAAAAAA + BBBBBBBBBBBBBBBBBB +
+                                   b + c);
 }


### PR DESCRIPTION
I'm quite new to Rust, so I picked this for practice. Please tell me if it's not idiomatic for Rust.