### PR TITLE
Optionally put the opening paren on the previous line for args (Issue #31)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct Config {
     pub newline_style: ::NewlineStyle,
     pub fn_brace_style: ::BraceStyle,
     pub fn_return_indent: ::ReturnIndent,
+    pub fn_args_paren_newline: bool,
     pub struct_trailing_comma: bool,
     pub struct_lit_trailing_comma: ::lists::SeparatorTactic,
 }

--- a/src/default.toml
+++ b/src/default.toml
@@ -5,5 +5,6 @@ tab_spaces = 4
 newline_style = "Unix"
 fn_brace_style = "SameLineWhere"
 fn_return_indent = "WithArgs"
+fn_args_paren_newline = true
 struct_trailing_comma = true
 struct_lit_trailing_comma = "Vertical"

--- a/src/items.rs
+++ b/src/items.rs
@@ -379,7 +379,7 @@ impl<'a> FmtVisitor<'a> {
 
         // Didn't work. we must force vertical layout and put args on a newline.
         if let None = budgets {
-            let new_indent = indent + 4;
+            let new_indent = indent + config!(tab_spaces);
             let used_space = new_indent + 2; // account for `(` and `)`
             let max_space = config!(ideal_width) + config!(leeway);
             if used_space > max_space {

--- a/src/items.rs
+++ b/src/items.rs
@@ -130,13 +130,26 @@ impl<'a> FmtVisitor<'a> {
         let ret_str = self.rewrite_return(&fd.output);
 
         // Args.
-        let (one_line_budget, multi_line_budget, arg_indent) =
-            self.compute_budgets_for_args(&mut result, indent, ret_str.len(), newline_brace);
+        let (one_line_budget, multi_line_budget, mut arg_indent) =
+            self.compute_budgets_for_args(&result, indent, ret_str.len(), newline_brace);
 
         debug!("rewrite_fn: one_line_budget: {}, multi_line_budget: {}, arg_indent: {}",
                one_line_budget, multi_line_budget, arg_indent);
 
-        result.push('(');
+        if one_line_budget <= 0 {
+            if config!(fn_args_paren_newline) {
+                result.push('\n');
+                result.push_str(&make_indent(arg_indent));
+                arg_indent = arg_indent + 1;
+                result.push('(');
+            } else {
+                result.push_str("(\n");
+                result.push_str(&make_indent(arg_indent));
+            }
+        } else {
+            result.push('(');
+        }
+
         result.push_str(&self.rewrite_args(&fd.inputs,
                                            explicit_self,
                                            one_line_budget,
@@ -330,7 +343,7 @@ impl<'a> FmtVisitor<'a> {
     }
 
     fn compute_budgets_for_args(&self,
-                                result: &mut String,
+                                result: &String,
                                 indent: usize,
                                 ret_str_len: usize,
                                 newline_brace: bool)
@@ -365,8 +378,6 @@ impl<'a> FmtVisitor<'a> {
 
         // Didn't work. we must force vertical layout and put args on a newline.
         if let None = budgets {
-            result.push('\n');
-            result.push_str(&make_indent(indent + 4));
             // 6 = new indent + `()`
             let used_space = indent + 6;
             let max_space = config!(ideal_width) + config!(leeway);
@@ -375,7 +386,7 @@ impl<'a> FmtVisitor<'a> {
                 // TODO take evasive action, perhaps kill the indent or something.
             } else {
                 // 5 = new indent + `(`
-                budgets = Some((0, max_space - used_space, indent + 5));
+                budgets = Some((0, max_space - used_space, indent + 4));
             }
         }
 

--- a/src/items.rs
+++ b/src/items.rs
@@ -136,11 +136,12 @@ impl<'a> FmtVisitor<'a> {
         debug!("rewrite_fn: one_line_budget: {}, multi_line_budget: {}, arg_indent: {}",
                one_line_budget, multi_line_budget, arg_indent);
 
+        // Check if vertical layout was forced by compute_budget_for_args.
         if one_line_budget <= 0 {
             if config!(fn_args_paren_newline) {
                 result.push('\n');
                 result.push_str(&make_indent(arg_indent));
-                arg_indent = arg_indent + 1;
+                arg_indent = arg_indent + 1; // extra space for `(`
                 result.push('(');
             } else {
                 result.push_str("(\n");
@@ -378,15 +379,14 @@ impl<'a> FmtVisitor<'a> {
 
         // Didn't work. we must force vertical layout and put args on a newline.
         if let None = budgets {
-            // 6 = new indent + `()`
-            let used_space = indent + 6;
+            let new_indent = indent + 4;
+            let used_space = new_indent + 2; // account for `(` and `)`
             let max_space = config!(ideal_width) + config!(leeway);
             if used_space > max_space {
                 // Whoops! bankrupt.
                 // TODO take evasive action, perhaps kill the indent or something.
             } else {
-                // 5 = new indent + `(`
-                budgets = Some((0, max_space - used_space, indent + 4));
+                budgets = Some((0, max_space - used_space, new_indent));
             }
         }
 


### PR DESCRIPTION
Added new config option `fn_args_paren_newline` to control this (defaults to previous behavior). Only tested locally --- I can add some testcases but I don't think there's support for per-test Config options.