### PR TITLE
Format expressions with binary and unary operators

### DIFF
--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -1,0 +1,14 @@
+// Test expressions
+
+fn foo() -> bool {
+    let very_long_variable_name = ( a +  first +   simple + test   );
+    let very_long_variable_name = (a + first + simple + test + AAAAAAAAAAAAA + BBBBBBBBBBBBBBBBB + b + c);
+
+    let some_val = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa * bbbb / (bbbbbb -
+        function_call(x, *very_long_pointer, y))
+    + 1000;
+
+some_ridiculously_loooooooooooooooooooooong_function(10000 * 30000000000 + 40000 / 1002200000000
+                                                     - 50000 * sqrt(-1),
+                                                     trivial_value)
+}

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -1,0 +1,14 @@
+// Test expressions
+
+fn foo() -> bool {
+    let very_long_variable_name = (a + first + simple + test);
+    let very_long_variable_name = (a + first + simple + test + AAAAAAAAAAAAA + BBBBBBBBBBBBBBBBB +
+                                   b + c);
+
+    let some_val = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa * bbbb /
+                   (bbbbbb - function_call(x, *very_long_pointer, y)) + 1000;
+
+    some_ridiculously_loooooooooooooooooooooong_function(10000 * 30000000000 +
+                                                         40000 / 1002200000000 - 50000 * sqrt(-1),
+                                                         trivial_value)
+}

--- a/tests/target/paren.rs
+++ b/tests/target/paren.rs
@@ -1,7 +1,0 @@
-// Test parenthesis
-
-fn foo() {
-    let very_long_variable_name = (a + first + simple + test);
-    let very_long_variable_name = (a + first + simple + test + AAAAAAAAAAAAA + BBBBBBBBBBBBBBBBBB +
-                                   b + c);
-}


### PR DESCRIPTION
I experimented quite a bit and think this is a decent heuristic for formatting binary operations. It's not very clear when a binary operation triggers a line break inside a function call, as it breaks the '1 parameter per line' pattern.

cc https://github.com/nrc/rustfmt/issues/29, https://github.com/nrc/rustfmt/issues/30