### PR TITLE
Format loop statements

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -251,7 +251,8 @@ impl<'a> FmtVisitor<'a> {
                 return self.rewrite_tuple_lit(items, width, offset);
             }
             ast::Expr_::ExprLoop(ref block, _) => {
-                return self.rewrite_loop(block);
+                self.rewrite_loop(block);
+                return "".to_string();
             }
             _ => {}
         }
@@ -259,7 +260,7 @@ impl<'a> FmtVisitor<'a> {
         self.snippet(expr.span)
     }
 
-    fn rewrite_loop(&mut self, block: &ast::Block) -> String {
+    fn rewrite_loop(&mut self, block: &ast::Block) {
         self.changes.push_str_span(block.span, "loop {");
 
         self.last_pos = block.span.lo + BytePos(1);
@@ -277,7 +278,5 @@ impl<'a> FmtVisitor<'a> {
         self.format_missing_with_indent(block.span.hi - BytePos(1));
 
         self.changes.push_str_span(block.span, "}");
-
-        return "".to_string()
     }
 }

--- a/tests/source/loop.rs
+++ b/tests/source/loop.rs
@@ -1,0 +1,7 @@
+
+fn looper() {
+loop       {}
+         loop{}
+loop
+{let x=1;let y=2;}
+}

--- a/tests/source/loop.rs
+++ b/tests/source/loop.rs
@@ -2,6 +2,14 @@
 fn looper() {
 loop       {}
          loop{}
+    loop {
+}
 loop
 {let x=1;let y=2;}
+
+loop /*comment1*/ {// comment2
+ /*comment3*/    let x=1;//comment4
+    let y=2;//comment5
+/*comment6*/}//comment7
+
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -152,7 +152,7 @@ fn handle_result(result: HashMap<String, String>) {
     for (file_name, fmt_text) in result {
         // If file is in tests/source, compare to file with same name in tests/target
         let target_file_name = get_target(&file_name);
-        let mut f = fs::File::open(&target_file_name).ok().expect("Couldn't open target.");
+        let mut f = fs::File::open(&target_file_name).ok().expect(&format!("Couldn't open target: {}", target_file_name));
 
         let mut text = String::new();
         // TODO: speedup by running through bytes iterator

--- a/tests/target/loop.rs
+++ b/tests/target/loop.rs
@@ -1,0 +1,11 @@
+
+fn looper() {
+    loop {
+    }
+    loop {
+    }
+    loop {
+        let x=1;
+        let y=2;
+    }
+}

--- a/tests/target/loop.rs
+++ b/tests/target/loop.rs
@@ -5,7 +5,15 @@ fn looper() {
     loop {
     }
     loop {
+    }
+    loop {
         let x=1;
         let y=2;
     }
+
+    loop {// comment2
+ /*comment3*/        let x=1;//comment4
+        let y=2;//comment5
+/*comment6*/    }//comment7
+
 }


### PR DESCRIPTION
Implements #102 


I thought loop would be a simple control statement to start with. I ended up hitting a few issues that I am not sure the best way to handle:

1) It seems expressions rewrite themselves by returning a `String` that is pushed onto the `ChangeSet` after the entire expression is formatted. Everything else seems to push onto the `ChangeSet` as it goes. 

loop causes the two techniques to mix. I match `ast::Expr_::ExprLoop` in `rewrite_expr`, which wants to create a `String`, but `ExprLoop` needs to format its block, which is done via direct `ChangeSet` manipulation (`visit::walk_block(self, block)` -> `FmtVisitor::visit_stmt`).

I started with the simplest thing I could think of, which was writing directly to the `ChangeSet` inside `rewrite_loop`. Maybe I should instead be handling the `ExprLoop` inside `visit_stmt` (matching inside a `StmtExpr`) so I don't have to pretend to build a `String`?

2) The `format_missing*` methods confuse me, and so does what the formatting rules should be when there are comments in awkward places. I wouldn't be surprised if I made some mistakes here.

I put a bunch of ugly comments in `tests/source/loops.rs`. The only one this implementation misses is `comment1`. What's the best way to keep track that we're currently dropping a comment here? Should I remove it from the test?

3) I had to manually add the semi-colon to the last statement in the loop's block. I'm not sure if there is a better way to handle that.