### PR TITLE
Add a Rewrite trait

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -8,9 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use visitor::FmtVisitor;
 use utils::*;
 use lists::{write_list, ListFormatting, SeparatorTactic, ListTactic};
+use rewrite::{Rewrite, RewriteContext};
 
 use syntax::{ast, ptr};
 use syntax::codemap::{Pos, Span};
@@ -19,194 +19,246 @@ use syntax::print::pprust;
 
 use MIN_STRING;
 
-impl<'a> FmtVisitor<'a> {
-    fn rewrite_string_lit(&mut self, s: &str, span: Span, width: usize, offset: usize) -> String {
-        // FIXME I bet this stomps unicode escapes in the source string
-
-        // Check if there is anything to fix: we always try to fixup multi-line
-        // strings, or if the string is too long for the line.
-        let l_loc = self.codemap.lookup_char_pos(span.lo);
-        let r_loc = self.codemap.lookup_char_pos(span.hi);
-        if l_loc.line == r_loc.line && r_loc.col.to_usize() <= config!(max_width) {
-            return self.snippet(span);
-        }
-
-        // TODO if lo.col > IDEAL - 10, start a new line (need cur indent for that)
-
-        let s = s.escape_default();
-
-        let offset = offset + 1;
-        let indent = make_indent(offset);
-        let indent = &indent;
-
-        let mut cur_start = 0;
-        let mut result = String::with_capacity(round_up_to_power_of_two(s.len()));
-        result.push('"');
-        loop {
-            let max_chars = if cur_start == 0 {
-                // First line.
-                width - 2 // 2 = " + \
-            } else {
-                config!(max_width) - offset - 1 // 1 = either \ or ;
-            };
-
-            let mut cur_end = cur_start + max_chars;
-
-            if cur_end >= s.len() {
-                result.push_str(&s[cur_start..]);
-                break;
-            }
-
-            // Make sure we're on a char boundary.
-            cur_end = next_char(&s, cur_end);
-
-            // Push cur_end left until we reach whitespace
-            while !s.char_at(cur_end-1).is_whitespace() {
-                cur_end = prev_char(&s, cur_end);
-
-                if cur_end - cur_start < MIN_STRING {
-                    // We can't break at whitespace, fall back to splitting
-                    // anywhere that doesn't break an escape sequence
-                    cur_end = next_char(&s, cur_start + max_chars);
-                    while s.char_at(prev_char(&s, cur_end)) == '\\' {
-                        cur_end = prev_char(&s, cur_end);
+impl Rewrite for ast::Expr {
+    fn rewrite(&self, context: &RewriteContext, width: usize, offset: usize) -> Option<String> {
+        match self.node {
+            ast::Expr_::ExprLit(ref l) => {
+                match l.node {
+                    ast::Lit_::LitStr(ref is, _) => {
+                        let result = rewrite_string_lit(context, &is, l.span, width, offset);
+                        debug!("string lit: `{:?}`", result);
+                        return result;
                     }
-                    break;
+                    _ => {}
                 }
             }
-            // Make sure there is no whitespace to the right of the break.
-            while cur_end < s.len() && s.char_at(cur_end).is_whitespace() {
-                cur_end = next_char(&s, cur_end+1);
+            ast::Expr_::ExprCall(ref callee, ref args) => {
+                return rewrite_call(context, callee, args, width, offset);
             }
-            result.push_str(&s[cur_start..cur_end]);
-            result.push_str("\\\n");
-            result.push_str(indent);
-
-            cur_start = cur_end;
+            ast::Expr_::ExprParen(ref subexpr) => {
+                return rewrite_paren(context, subexpr, width, offset);
+            }
+            ast::Expr_::ExprStruct(ref path, ref fields, ref base) => {
+                return rewrite_struct_lit(context, path,
+                                               fields,
+                                               base.as_ref().map(|e| &**e),
+                                               width,
+                                               offset);
+            }
+            ast::Expr_::ExprTup(ref items) => {
+                return rewrite_tuple_lit(context, items, width, offset);
+            }
+            _ => {}
         }
-        result.push('"');
 
-        result
+        context.codemap.span_to_snippet(self.span).ok()
+    }
+}
+
+fn rewrite_string_lit(context: &RewriteContext, s: &str, span: Span, width: usize, offset: usize) -> Option<String> {
+    // FIXME I bet this stomps unicode escapes in the source string
+
+    // Check if there is anything to fix: we always try to fixup multi-line
+    // strings, or if the string is too long for the line.
+    let l_loc = context.codemap.lookup_char_pos(span.lo);
+    let r_loc = context.codemap.lookup_char_pos(span.hi);
+    if l_loc.line == r_loc.line && r_loc.col.to_usize() <= config!(max_width) {
+        return context.codemap.span_to_snippet(span).ok();
     }
 
-    fn rewrite_call(&mut self,
+    // TODO if lo.col > IDEAL - 10, start a new line (need cur indent for that)
+
+    let s = s.escape_default();
+
+    let offset = offset + 1;
+    let indent = make_indent(offset);
+    let indent = &indent;
+
+    let mut cur_start = 0;
+    let mut result = String::with_capacity(round_up_to_power_of_two(s.len()));
+    result.push('"');
+    loop {
+        let max_chars = if cur_start == 0 {
+            // First line.
+            width - 2 // 2 = " + \
+        } else {
+            config!(max_width) - offset - 1 // 1 = either \ or ;
+        };
+
+        let mut cur_end = cur_start + max_chars;
+
+        if cur_end >= s.len() {
+            result.push_str(&s[cur_start..]);
+            break;
+        }
+
+        // Make sure we're on a char boundary.
+        cur_end = next_char(&s, cur_end);
+
+        // Push cur_end left until we reach whitespace
+        while !s.char_at(cur_end-1).is_whitespace() {
+            cur_end = prev_char(&s, cur_end);
+
+            if cur_end - cur_start < MIN_STRING {
+                // We can't break at whitespace, fall back to splitting
+                // anywhere that doesn't break an escape sequence
+                cur_end = next_char(&s, cur_start + max_chars);
+                while s.char_at(prev_char(&s, cur_end)) == '\\' {
+                    cur_end = prev_char(&s, cur_end);
+                }
+                break;
+            }
+        }
+        // Make sure there is no whitespace to the right of the break.
+        while cur_end < s.len() && s.char_at(cur_end).is_whitespace() {
+            cur_end = next_char(&s, cur_end+1);
+        }
+        result.push_str(&s[cur_start..cur_end]);
+        result.push_str("\\\n");
+        result.push_str(indent);
+
+        cur_start = cur_end;
+    }
+    result.push('"');
+
+    Some(result)
+}
+
+fn rewrite_call(context: &RewriteContext,
                     callee: &ast::Expr,
                     args: &[ptr::P<ast::Expr>],
                     width: usize,
                     offset: usize)
-        -> String
-    {
-        debug!("rewrite_call, width: {}, offset: {}", width, offset);
+        -> Option<String>
+{
+    debug!("rewrite_call, width: {}, offset: {}", width, offset);
 
-        // TODO using byte lens instead of char lens (and probably all over the place too)
-        let callee_str = self.rewrite_expr(callee, width, offset);
-        debug!("rewrite_call, callee_str: `{}`", callee_str);
-        // 2 is for parens.
-        let remaining_width = width - callee_str.len() - 2;
-        let offset = callee_str.len() + 1 + offset;
-        let arg_count = args.len();
+    // TODO using byte lens instead of char lens (and probably all over the place too)
+    let callee_str = match callee.rewrite(context, width, offset) {
+        Some(s) => s,
+        None => { return None; }
+    };
+    debug!("rewrite_call, callee_str: `{:?}`", callee_str);
+    // 2 is for parens.
+    let remaining_width = width - callee_str.len() - 2;
+    let offset = callee_str.len() + 1 + offset;
+    let arg_count = args.len();
 
-        let args_str = if arg_count > 0 {
-            let args: Vec<_> = args.iter().map(|e| (self.rewrite_expr(e,
-                                                                      remaining_width,
-                                                                      offset), String::new())).collect();
-            let fmt = ListFormatting {
-                tactic: ListTactic::HorizontalVertical,
-                separator: ",",
-                trailing_separator: SeparatorTactic::Never,
-                indent: offset,
-                h_width: remaining_width,
-                v_width: remaining_width,
-            };
-            write_list(&args, &fmt)
-        } else {
-            String::new()
+    let args_str = if arg_count > 0 {
+        let mut args_rewritten = Vec::with_capacity(args.len());
+        for arg in args.iter() {
+            match arg.rewrite(context, remaining_width, offset) {
+                Some(s) => { args_rewritten.push((s, String::new())); }
+                None => { return None; }
+            }
+        }
+        let fmt = ListFormatting {
+            tactic: ListTactic::HorizontalVertical,
+            separator: ",",
+            trailing_separator: SeparatorTactic::Never,
+            indent: offset,
+            h_width: remaining_width,
+            v_width: remaining_width,
         };
+        write_list(&args_rewritten, &fmt)
+    } else {
+        String::new()
+    };
 
-        format!("{}({})", callee_str, args_str)
-    }
+    Some(format!("{}({})", callee_str, args_str))
+}
 
-    fn rewrite_paren(&mut self, subexpr: &ast::Expr, width: usize, offset: usize) -> String {
-        debug!("rewrite_paren, width: {}, offset: {}", width, offset);
-        // 1 is for opening paren, 2 is for opening+closing, we want to keep the closing
-        // paren on the same line as the subexpr
-        let subexpr_str = self.rewrite_expr(subexpr, width-2, offset+1);
-        debug!("rewrite_paren, subexpr_str: `{}`", subexpr_str);
-        format!("({})", subexpr_str)
-    }
+fn rewrite_paren(context: &RewriteContext, subexpr: &ast::Expr, width: usize, offset: usize) -> Option<String> {
+    debug!("rewrite_paren, width: {}, offset: {}", width, offset);
+    // 1 is for opening paren, 2 is for opening+closing, we want to keep the closing
+    // paren on the same line as the subexpr
+    let subexpr_str = subexpr.rewrite(context, width-2, offset+1);
+    debug!("rewrite_paren, subexpr_str: `{:?}`", subexpr_str);
+    subexpr_str.map(|s| format!("({})", s))
+}
 
-    fn rewrite_struct_lit(&mut self,
+fn rewrite_struct_lit(context: &RewriteContext,
                           path: &ast::Path,
                           fields: &[ast::Field],
                           base: Option<&ast::Expr>,
                           width: usize,
                           offset: usize)
-        -> String
-    {
-        debug!("rewrite_struct_lit: width {}, offset {}", width, offset);
-        assert!(fields.len() > 0 || base.is_some());
+        -> Option<String>
+{
+    debug!("rewrite_struct_lit: width {}, offset {}", width, offset);
+    assert!(fields.len() > 0 || base.is_some());
 
-        let path_str = pprust::path_to_string(path);
-        // Foo { a: Foo } - indent is +3, width is -5.
-        let indent = offset + path_str.len() + 3;
-        let budget = width - (path_str.len() + 5);
+    let path_str = pprust::path_to_string(path);
+    // Foo { a: Foo } - indent is +3, width is -5.
+    let indent = offset + path_str.len() + 3;
+    let budget = width - (path_str.len() + 5);
 
-        let mut field_strs: Vec<_> =
-            fields.iter().map(|f| self.rewrite_field(f, budget, indent)).collect();
-        if let Some(expr) = base {
-            // Another 2 on the width/indent for the ..
-            field_strs.push(format!("..{}", self.rewrite_expr(expr, budget - 2, indent + 2)))
+    let mut field_strs = Vec::with_capacity(fields.len());
+    for field in fields.iter() {
+        match rewrite_field(context, field, budget, indent) {
+            Some(s) => { field_strs.push(s); }
+            None => { return None; }
         }
+    }
+    if let Some(expr) = base {
+        // Another 2 on the width/indent for the ..
+        field_strs.push(match expr.rewrite(context, budget - 2, indent + 2) {
+            Some(s) => format!("..{}", s),
+            None => { return None; }
+        });
+    }
 
-        // FIXME comments
-        let field_strs: Vec<_> = field_strs.into_iter().map(|s| (s, String::new())).collect();
-        let fmt = ListFormatting {
-            tactic: ListTactic::HorizontalVertical,
-            separator: ",",
-            trailing_separator: if base.is_some() {
-                    SeparatorTactic::Never
-                } else {
-                    config!(struct_lit_trailing_comma)
-                },
-            indent: indent,
-            h_width: budget,
-            v_width: budget,
-        };
-        let fields_str = write_list(&field_strs, &fmt);
-        format!("{} {{ {} }}", path_str, fields_str)
+    // FIXME comments
+    let field_strs: Vec<_> = field_strs.into_iter().map(|s| (s, String::new())).collect();
+    let fmt = ListFormatting {
+        tactic: ListTactic::HorizontalVertical,
+        separator: ",",
+        trailing_separator: if base.is_some() {
+            SeparatorTactic::Never
+        } else {
+            config!(struct_lit_trailing_comma)
+        },
+        indent: indent,
+        h_width: budget,
+        v_width: budget,
+    };
+    let fields_str = write_list(&field_strs, &fmt);
+    Some(format!("{} {{ {} }}", path_str, fields_str))
 
         // FIXME if the usual multi-line layout is too wide, we should fall back to
         // Foo {
         //     a: ...,
         // }
-    }
+}
 
-    fn rewrite_field(&mut self, field: &ast::Field, width: usize, offset: usize) -> String {
-        let name = &token::get_ident(field.ident.node);
-        let overhead = name.len() + 2;
-        let expr = self.rewrite_expr(&field.expr, width - overhead, offset + overhead);
-        format!("{}: {}", name, expr)
-    }
+fn rewrite_field(context: &RewriteContext, field: &ast::Field, width: usize, offset: usize) -> Option<String> {
+    let name = &token::get_ident(field.ident.node);
+    let overhead = name.len() + 2;
+    let expr = field.expr.rewrite(context, width - overhead, offset + overhead);
+    expr.map(|s| format!("{}: {}", name, s))
+}
 
-    fn rewrite_tuple_lit(&mut self, items: &[ptr::P<ast::Expr>], width: usize, offset: usize)
-        -> String {
+fn rewrite_tuple_lit(context: &RewriteContext, items: &[ptr::P<ast::Expr>], width: usize, offset: usize)
+    -> Option<String> {
         // opening paren
         let indent = offset + 1;
         // In case of length 1, need a trailing comma
         if items.len() == 1 {
-            return format!("({},)", self.rewrite_expr(&*items[0], width - 3, indent));
+            return items[0].rewrite(context, width - 3, indent).map(|s| format!("({},)", s));
         }
         // Only last line has width-1 as budget, other may take max_width
-        let item_strs: Vec<_> =
-            items.iter()
-                 .enumerate()
-                 .map(|(i, item)| self.rewrite_expr(
-                    item,
-                    // last line : given width (minus "("+")"), other lines : max_width
-                    // (minus "("+","))
-                    if i == items.len() - 1 { width - 2 } else { config!(max_width) - indent - 2 },
-                    indent))
-                 .collect();
+        let mut item_strs = Vec::with_capacity(items.len());
+        for (i, item) in items.iter().enumerate() {
+            let rem_width = if i == items.len() - 1 {
+                width - 2
+            } else {
+                config!(max_width) - indent - 2
+            };
+            match item.rewrite(context, rem_width, indent) {
+                Some(s) => { item_strs.push(s); }
+                None => {return None; }
+            }
+        }
         let tactics = if item_strs.iter().any(|s| s.contains('\n')) {
             ListTactic::Vertical
         } else {
@@ -223,41 +275,5 @@ impl<'a> FmtVisitor<'a> {
             v_width: width - 2,
         };
         let item_str = write_list(&item_strs, &fmt);
-        format!("({})", item_str)
+        Some(format!("({})", item_str))
     }
-
-
-    pub fn rewrite_expr(&mut self, expr: &ast::Expr, width: usize, offset: usize) -> String {
-        match expr.node {
-            ast::Expr_::ExprLit(ref l) => {
-                match l.node {
-                    ast::Lit_::LitStr(ref is, _) => {
-                        let result = self.rewrite_string_lit(&is, l.span, width, offset);
-                        debug!("string lit: `{}`", result);
-                        return result;
-                    }
-                    _ => {}
-                }
-            }
-            ast::Expr_::ExprCall(ref callee, ref args) => {
-                return self.rewrite_call(callee, args, width, offset);
-            }
-            ast::Expr_::ExprParen(ref subexpr) => {
-                return self.rewrite_paren(subexpr, width, offset);
-            }
-            ast::Expr_::ExprStruct(ref path, ref fields, ref base) => {
-                return self.rewrite_struct_lit(path,
-                                               fields,
-                                               base.as_ref().map(|e| &**e),
-                                               width,
-                                               offset);
-            }
-            ast::Expr_::ExprTup(ref items) => {
-                return self.rewrite_tuple_lit(items, width, offset);
-            }
-            _ => {}
-        }
-
-        self.snippet(expr.span)
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ mod types;
 mod expr;
 mod imports;
 mod issues;
+mod rewrite;
 
 const MIN_STRING: usize = 10;
 // When we get scoped annotations, we should have rustfmt::skip.

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -8,9 +8,18 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+// A generic trait to abstract the rewriting of an element (of the AST).
+
 use syntax::codemap::CodeMap;
 
 pub trait Rewrite {
+    /// Rewrite self into offset and width.
+    /// `offset` is the indentation of the first line. The next lines
+    /// should begin with a least `offset` spaces (except backwards
+    /// indentation). The first line should not begin with indentation.
+    /// `width` is the maximum number of characters on the last line
+    /// (excluding offset). The width of other lines is not limited by
+    /// `width`.
     fn rewrite(&self, context: &RewriteContext, width: usize, offset: usize) -> Option<String>;
 }
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1,0 +1,19 @@
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use syntax::codemap::CodeMap;
+
+pub trait Rewrite {
+    fn rewrite(&self, context: &RewriteContext, width: usize, offset: usize) -> Option<String>;
+}
+
+pub struct RewriteContext<'a> {
+    pub codemap: &'a CodeMap,
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -159,6 +159,15 @@ macro_rules! impl_enum_decodable {
     };
 }
 
+// Same as try!, but for Option
+#[macro_export]
+macro_rules! try_opt {
+    ($expr:expr) => (match $expr {
+        Some(val) => val,
+        None => { return None; }
+    })
+}
+
 #[test]
 fn power_rounding() {
     assert_eq!(0, round_up_to_power_of_two(0));

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -37,7 +37,6 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
                          config!(max_width) - offset,
                          offset) {
             Some(new_str) => {
-                //let new_str = self.rewrite_expr(ex, config!(max_width) - offset, offset);
                 self.changes.push_str_span(ex.span, &new_str);
                 self.last_pos = ex.span.hi;
             }


### PR DESCRIPTION
This PR is just a proposal of a new trait, and is primarily intended for discussion. It's a draft of implementation of an idea I wanted to share and discuss. It's just an idea, that will maybe not well work.

Because it might change a lot of code, I prefer to discuss it before a complete implementation.

Motivation
---------

We have a recurrent pattern in the code: rewrite some code with a given offset and width. (It's very common in `expr.rs`, for example).

I wanted to abstract "something that can be rewritten into offset and width" when working on list formatting. Format a list (of args, types parameters...) is also something useful. With the current `lists` module, it needs some recurrent code, essentially : rewrite all items of the list within a maximal width, but the last one within the given width.

I found a lot of these patterns when I tried to format types (`ast::Ty`).

Design
-------

The idea is quite simple: add a new trait `Rewrite` to represent the 
```rust
pub trait Rewrite {
    fn rewrite(&self, width: usize, offset: usize) -> Option<(String, Option<Comment>)>;
}
```
`rewrite` returns an `Option` to express the fact that it's sometime not possible to not excess the given width. (Should it be a `Result` instead ?) The first element of the tuple (`String`) is the code formatted, and the second is a possible comment. Getting the comment separated of the code gives more degrees of freedom to the caller : it can put the comment on an own line before the code, of at the end of the line. The enum `Comment` is intended to be able to make a difference between a doc comment and another kind of comment (we will eventually replace bloc comments with line comments), but it's maybe not useful and a simple string would be sufficient.

The current implementation of this trait to format lists is only used by a place-holder for the `write_list` function.

At the very end, all `rewrite_*` functions could be impls of `Rewrite`.

When it comes to implement and use this trait, things are getting wrong : it makes sense to implement it for `ast::Expr`, and using `rewrite_expr` as the `rewrite` method, but it doesn't work since `rewrite_expr` is itself a method of `FmtVisitor`.

I see two solutions to this problem : in the longterm, we might have a self-sufficient AST, and `FmtVisitor` would not more be needed. Currently, it's not possible though. The second solution is to create structs containing the item we want to format and a ref to the `FmtVisitor`. I don't know if this approach would be sustainable if we use it extensively. There is maybe another solution. (?)

I tried also an alternative, which is a more ad-hoc solution : pass the rewriting function as argument of `rewrite_list`. It looked me a bit "hackish" and less extensible, but maybe it's only because i'm not used to that.

So, please let me know what you think about it.

About the list formatting algorithm, and tuple formatting, the changes are not very relevant, it's just an example of impl of `Rewrite`. The tuple formatting is a good example of use case for `Rewrite` : the same algorithm may be used for tuple litterals and for tuple types.