### PR TITLE
Update import list formatting

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -46,9 +46,16 @@ pub fn rewrite_comment(orig: &str, block_style: bool, width: usize, offset: usiz
                 line = &line[..(line.len() - 2)];
             }
 
-            line.trim_right_matches(' ')
+            line.trim_right()
         })
         .map(left_trim_comment_line)
+        .map(|line| {
+            if line_breaks == 0 {
+                line.trim_left()
+            } else {
+                line
+            }
+        })
         .fold((true, opener.to_owned()), |(first, mut acc), line| {
             if !first {
                 acc.push('\n');
@@ -98,6 +105,8 @@ fn format_comments() {
                             * men\n                                                                      \
                             * t */";
     assert_eq!(expected_output, rewrite_comment(input, true, 9, 69));
+
+    assert_eq!("/* trimmed */", rewrite_comment("/*   trimmed    */", true, 100, 100));
 }
 
 
@@ -156,6 +165,7 @@ fn test_find_uncommented() {
     check("/*sup yo? \n sup*/ sup", "p", Some(20));
     check("hel/*lohello*/lo", "hello", None);
     check("acb", "ab", None);
+    check(",/*A*/ ", ",", Some(0));
 }
 
 // Returns the first byte position after the first comment. The given string

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub enum_trailing_comma: bool,
     pub report_todo: ReportTactic,
     pub report_fixme: ReportTactic,
+    pub reorder_imports: bool, // Alphabetically, case sensitive.
 }
 
 impl Config {

--- a/src/default.toml
+++ b/src/default.toml
@@ -11,3 +11,4 @@ struct_lit_trailing_comma = "Vertical"
 enum_trailing_comma = true
 report_todo = "Always"
 report_fixme = "Never"
+reorder_imports = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(rustc_private)]
 #![feature(str_escape)]
 #![feature(str_char)]
+#![feature(slice_extras)]
 
 // TODO we're going to allocate a whole bunch of temp Strings, is it worth
 // keeping some scratch mem for this and running our own StrPool?

--- a/src/string.rs
+++ b/src/string.rs
@@ -88,16 +88,3 @@ pub fn rewrite_string<'a>(s: &str, fmt: &StringFormat<'a>) -> String {
 
     result
 }
-
-#[inline]
-// Checks if a appears before b in given string and, if so, returns the index of
-// a.
-// FIXME: could be more generic
-pub fn before<'x>(s: &'x str, a: &str, b: &str) -> Option<usize> {
-    s.find(a).and_then(|i| {
-        match s.find(b) {
-            Some(j) if j <= i => None,
-            _ => Some(i)
-        }
-    })
-}

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -168,7 +168,8 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
                                                               multi_line_budget,
                                                               path,
                                                               path_list,
-                                                              item.vis);
+                                                              item.vis,
+                                                              item.span);
 
                         if let Some(new_str) = formatted {
                             self.format_missing_with_indent(item.span.lo);
@@ -186,9 +187,12 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
                         self.last_pos = item.span.hi;
                     }
                     ast::ViewPath_::ViewPathGlob(_) => {
+                        self.format_missing_with_indent(item.span.lo);
                         // FIXME convert to list?
                     }
-                    ast::ViewPath_::ViewPathSimple(_,_) => {}
+                    ast::ViewPath_::ViewPathSimple(_,_) => {
+                        self.format_missing_with_indent(item.span.lo);
+                    }
                 }
                 visit::walk_item(self, item);
             }

--- a/tests/config/reorder_imports.toml
+++ b/tests/config/reorder_imports.toml
@@ -1,7 +1,7 @@
 max_width = 100
 ideal_width = 80
 leeway = 5
-tab_spaces = 2
+tab_spaces = 4
 newline_style = "Unix"
 fn_brace_style = "SameLineWhere"
 fn_return_indent = "WithArgs"
@@ -11,4 +11,4 @@ struct_lit_trailing_comma = "Vertical"
 enum_trailing_comma = true
 report_todo = "Always"
 report_fixme = "Never"
-reorder_imports = false
+reorder_imports = true

--- a/tests/source/imports-reorder.rs
+++ b/tests/source/imports-reorder.rs
@@ -1,0 +1,5 @@
+// rustfmt-config: reorder_imports.toml
+
+use path::{C,/*A*/ A, B /* B */, self /* self */};
+
+use {ab, ac, aa, Z, b};

--- a/tests/source/imports.rs
+++ b/tests/source/imports.rs
@@ -1,0 +1,41 @@
+// Imports.
+
+// Long import.
+use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};
+use exceedingly::looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{ItemA,
+                                                                                                ItemB};
+
+use list::{
+    // Some item
+    SomeItem /* Comment */, /* Another item */ AnotherItem /* Another Comment */, // Last Item
+    LastItem
+};
+
+use test::{  Other          /* C   */  , /*   A   */ self  /*    B     */    };
+
+use syntax::{self};
+use {/* Pre-comment! */
+     Foo, Bar /* comment */};
+use Foo::{Bar, Baz};
+pub use syntax::ast::{Expr_, Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath};
+use syntax::some::{};
+
+mod Foo {
+    pub use syntax::ast::{
+        ItemForeignMod,
+        ItemImpl, 
+        ItemMac,
+        ItemMod,
+        ItemStatic, 
+        ItemDefaultImpl
+    };
+
+    mod Foo2 {
+        pub use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, self, ItemDefaultImpl};
+    }
+}
+
+fn test() {
+use Baz::*;
+        use Qux;
+}

--- a/tests/target/imports-reorder.rs
+++ b/tests/target/imports-reorder.rs
@@ -1,0 +1,5 @@
+// rustfmt-config: reorder_imports.toml
+
+use path::{self /* self */, /* A */ A, B /* B */, C};
+
+use {Z, aa, ab, ac, b};

--- a/tests/target/imports.rs
+++ b/tests/target/imports.rs
@@ -5,7 +5,17 @@ use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDe
 use exceedingly::looooooooooooooooooooooooooooooooooooooooooooooooooooooooooong::import::path::{ItemA,
                                                                                                 ItemB};
 
-use {Foo, Bar};
+use list::{// Some item
+           SomeItem, // Comment
+           // Another item
+           AnotherItem, // Another Comment
+           // Last Item
+           LastItem};
+
+use test::{/* A */ self /* B */, Other /* C */};
+
+use syntax;
+use {/* Pre-comment! */ Foo, Bar /* comment */};
 use Foo::{Bar, Baz};
 pub use syntax::ast::{Expr_, Expr, ExprAssign, ExprCall, ExprMethodCall, ExprPath};
 
@@ -13,11 +23,12 @@ mod Foo {
     pub use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};
 
     mod Foo2 {
-        pub use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod,
+        pub use syntax::ast::{self, ItemForeignMod, ItemImpl, ItemMac, ItemMod,
                               ItemStatic, ItemDefaultImpl};
     }
 }
 
 fn test() {
     use Baz::*;
+    use Qux;
 }


### PR DESCRIPTION
Adds comments and sorts items alphabetically. This is based on https://github.com/nrc/rustfmt/pull/93, to use the updated `write_list`.