### PR TITLE
Fix bugs in width computation for bin op

### DIFF
--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -10,5 +10,7 @@ fn foo() -> bool {
 
 some_ridiculously_loooooooooooooooooooooong_function(10000 * 30000000000 + 40000 / 1002200000000
                                                      - 50000 * sqrt(-1),
-                                                     trivial_value)
+                                                     trivial_value);
+    (((((((((aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + a +
+             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + aaaaa)))))))))
 }

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -10,5 +10,8 @@ fn foo() -> bool {
 
     some_ridiculously_loooooooooooooooooooooong_function(10000 * 30000000000 +
                                                          40000 / 1002200000000 - 50000 * sqrt(-1),
-                                                         trivial_value)
+                                                         trivial_value);
+    (((((((((aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+             a + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+             aaaaa)))))))))
 }


### PR DESCRIPTION
I didn't had enough time to review and test @nrc merged, so I correct here a bug in #99 : `lhs` was formatted into `width`, and `rhs` into `max_width`, while the inverse should be done.
