### PR TITLE
Implement basic lookup of config files.

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -9,17 +9,37 @@
 // except according to those terms.
 
 #![cfg(not(test))]
+#![feature(path_ext)]
 
 extern crate rustfmt;
 
 use rustfmt::{WriteMode, run};
 
-use std::fs::File;
-use std::io::Read;
+use std::env;
+use std::fs::{File, PathExt};
+use std::io::{self, Read, Error, ErrorKind};
+use std::path::PathBuf;
+
+fn lookup_config_file() -> io::Result<PathBuf> {
+    let mut current = try!(env::current_dir());
+    loop {
+        let config_file = current.join("default.toml");
+        if config_file.exists() {
+            return Ok(config_file);
+        } else {
+            current = match current.parent() {
+                // if the current directory has no parent, we're done searching
+                None => return Err(Error::new(ErrorKind::NotFound, "config not found")),
+                Some(path) => path.to_path_buf(),
+            };
+        }
+    }
+}
 
 fn main() {
     let args: Vec<_> = std::env::args().collect();
-    let mut def_config_file = File::open("default.toml").unwrap();
+    let config_path = lookup_config_file().unwrap();
+    let mut def_config_file = File::open(config_path).unwrap();
     let mut def_config = String::new();
     def_config_file.read_to_string(&mut def_config).unwrap();
 


### PR DESCRIPTION
This tries to find a configuration file in the current folder or the parent folders (git does a similar thing to find the repository's root). It's useful when you use the tool from a subfolder. It also doesn't break the current behaviour. #72