### PR TITLE
Format loops

### DIFF
--- a/src/changes.rs
+++ b/src/changes.rs
@@ -99,6 +99,14 @@ impl<'a> ChangeSet<'a> {
         self.push_str(&file_name, text)
     }
 
+    // Fetch the output buffer for the given file name.
+    // Panics on unknown files.
+    pub fn get(&mut self, file_name: &str) -> &StringBuffer {
+        self.file_map.get(file_name).unwrap()
+    }
+
+    // Fetch a mutable reference to the output buffer for the given file name.
+    // Panics on unknown files.
     pub fn get_mut(&mut self, file_name: &str) -> &mut StringBuffer {
         self.file_map.get_mut(file_name).unwrap()
     }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -28,4 +28,5 @@ pub trait Rewrite {
 pub struct RewriteContext<'a> {
     pub codemap: &'a CodeMap,
     pub config: &'a Config,
+    pub block_indent: usize,
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -38,7 +38,9 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
                self.codemap.lookup_char_pos(ex.span.hi));
         self.format_missing(ex.span.lo);
         let offset = self.changes.cur_offset_span(ex.span);
-        let context = RewriteContext { codemap: self.codemap, config: self.config };
+        let context = RewriteContext { codemap: self.codemap,
+                                       config: self.config,
+                                       block_indent: self.block_indent, };
         let rewrite = ex.rewrite(&context, self.config.max_width - offset, offset);
 
         if let Some(new_str) = rewrite {

--- a/tests/source/loop.rs
+++ b/tests/source/loop.rs
@@ -1,0 +1,11 @@
+
+fn main() {
+    loop    
+    {   return some_val;}
+
+let x = loop { do_forever(); };
+
+         loop {
+        // Just comments
+    }
+}

--- a/tests/target/loop.rs
+++ b/tests/target/loop.rs
@@ -1,0 +1,14 @@
+
+fn main() {
+    loop {
+        return some_val;
+    }
+
+    let x = loop {
+        do_forever();
+    };
+
+    loop {
+        // Just comments
+    }
+}


### PR DESCRIPTION
This was previously attempted by @chellmuth in https://github.com/nrc/rustfmt/pull/103. It hasn't seen any activity in three weeks, so I've taken the liberty to try as well.

My approach was as suggested in https://github.com/nrc/rustfmt/pull/103#issuecomment-111297423. While it is not optimal performance-wise, it has a low complexity. If this deemed acceptable for now, we can use it to easily format a whole class of expressions like if-else statements and even match blocks!