### PR TITLE
Fix bug in rewrite_tup_lit

### DIFF
--- a/tests/target/tuple.rs
+++ b/tests/target/tuple.rs
@@ -13,3 +13,17 @@ fn foo() {
              b, // Comment
              b /* Trailing comment */);
 }
+
+fn a() {
+    ((aaaaaaaa,
+      aaaaaaaaaaaaa,
+      aaaaaaaaaaaaaaaaa,
+      aaaaaaaaaaaaaa,
+      aaaaaaaaaaaaaaaa,
+      aaaaaaaaaaaaaa),)
+}
+
+fn b() {
+    ((bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb),
+     bbbbbbbbbbbbbbbbbb)
+}


### PR DESCRIPTION
Wasn't using all width available when the lenght is more than 1.