### PR TITLE
Format if expressions & loops

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -17,9 +17,11 @@ pub fn rewrite_comment(orig: &str, block_style: bool, width: usize, offset: usiz
     let s = orig.trim();
 
     // Edge case: block comments. Let's not trim their lines (for now).
-    let opener = if block_style { "/* " } else { "// " };
-    let closer = if block_style { " */" } else { "" };
-    let line_start = if block_style { " * " } else { "// " };
+    let (opener, closer, line_start) = if block_style {
+        ("/* ", " */", " * ")
+    } else {
+        ("// ", "", "// ")
+    };
 
     let max_chars = width.checked_sub(closer.len()).unwrap_or(1)
                          .checked_sub(opener.len()).unwrap_or(1);

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,18 @@ use {NewlineStyle, BraceStyle, ReturnIndent, StructLitStyle};
 use lists::SeparatorTactic;
 use issues::ReportTactic;
 
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum BlockIndentStyle {
+    // Same level as parent.
+    Inherit,
+    // One level deeper than parent.
+    Tabbed,
+    // Aligned with block open.
+    Visual,
+}
+
+impl_enum_decodable!(BlockIndentStyle, Inherit, Tabbed, Visual);
+
 #[derive(RustcDecodable, Clone)]
 pub struct Config {
     pub max_width: usize,
@@ -31,6 +43,7 @@ pub struct Config {
     pub report_todo: ReportTactic,
     pub report_fixme: ReportTactic,
     pub reorder_imports: bool, // Alphabetically, case sensitive.
+    pub expr_indent_style: BlockIndentStyle,
 }
 
 impl Config {

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -76,6 +76,17 @@ impl Rewrite for ast::Expr {
                     format!("{}loop {}", rewrite_label(label), result)
                 })
             }
+            ast::Expr_::ExprBlock(ref block) => {
+                block.rewrite(context, width, offset)
+            }
+            ast::Expr_::ExprIf(ref cond, ref if_block, ref else_block) => {
+                rewrite_if_else(context,
+                                cond,
+                                if_block,
+                                else_block.as_ref().map(|e| &**e),
+                                width,
+                                offset)
+            }
             _ => context.codemap.span_to_snippet(self.span).ok()
         }
     }
@@ -105,6 +116,29 @@ fn rewrite_label(label: Option<ast::Ident>) -> String {
     match label {
         Some(ident) => format!("{}: ", ident.as_str()),
         None => "".to_owned()
+    }
+}
+
+fn rewrite_if_else(context: &RewriteContext,
+                   cond: &ast::Expr,
+                   if_block: &ast::Block,
+                   else_block: Option<&ast::Expr>,
+                   width: usize,
+                   offset: usize)
+                   -> Option<String> {
+    // FIXME: missing comments between control statements and blocks
+    let cond_string = try_opt!(cond.rewrite(context, width - 3 - 2, offset + 3));
+    let if_block_string = try_opt!(if_block.rewrite(context, width, offset));
+
+    match else_block {
+        Some(else_block) => {
+            else_block.rewrite(context, width, offset).map(|else_block_string| {
+                format!("if {} {} else {}", cond_string, if_block_string, else_block_string)
+            })
+        }
+        None => {
+            Some(format!("if {} {}", cond_string, if_block_string))
+        }
     }
 }
 
@@ -229,6 +263,8 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
     let field_iter = fields.into_iter().map(StructLitField::Regular)
                            .chain(base.into_iter().map(StructLitField::Base));
 
+    let inner_context = &RewriteContext { block_indent: indent, ..*context };
+
     let items = itemize_list(context.codemap,
                              Vec::new(),
                              field_iter,
@@ -250,13 +286,13 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
                              |item| {
                                  match *item {
                                      StructLitField::Regular(ref field) => {
-                                         rewrite_field(context, &field, h_budget, indent)
+                                         rewrite_field(inner_context, &field, h_budget, indent)
                                             .unwrap_or(context.codemap.span_to_snippet(field.span)
                                                                       .unwrap())
                                      },
                                      StructLitField::Base(ref expr) => {
                                          // 2 = ..
-                                         expr.rewrite(context, h_budget - 2, indent + 2)
+                                         expr.rewrite(inner_context, h_budget - 2, indent + 2)
                                              .map(|s| format!("..{}", s))
                                              .unwrap_or(context.codemap.span_to_snippet(expr.span)
                                                                        .unwrap())

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -123,10 +123,10 @@ impl<'a> FmtVisitor<'a> {
         let list = write_list(&items[first_index..], &fmt);
 
         Some(if path_str.len() == 0 {
-            format!("{}use {{{}}};", vis, list)
-        } else {
-            format!("{}use {}::{{{}}};", vis, path_str, list)
-        })
+                format!("{}use {{{}}};", vis, list)
+            } else {
+                format!("{}use {}::{{{}}};", vis, path_str, list)
+            })
     }
 }
 

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -60,7 +60,11 @@ impl<'a> FmtVisitor<'a> {
         }
 
         // 2 = ::
-        let path_separation_w = if path_str.len() > 0 { 2 } else { 0 };
+        let path_separation_w = if path_str.len() > 0 {
+            2
+        } else {
+            0
+        };
         // 5 = "use " + {
         let indent = path_str.len() + 5 + path_separation_w + vis.len();
 
@@ -106,7 +110,11 @@ impl<'a> FmtVisitor<'a> {
         // FIXME: Make more efficient by using a linked list? That would
         // require changes to the signatures of itemize_list and write_list.
         let has_self = move_self_to_front(&mut items);
-        let first_index = if has_self { 0 } else { 1 };
+        let first_index = if has_self {
+            0
+        } else {
+            1
+        };
 
         if self.config.reorder_imports {
             items[1..].sort_by(|a, b| a.item.cmp(&b.item));

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -70,7 +70,11 @@ impl fmt::Display for Issue {
             IssueType::Todo => "TODO",
             IssueType::Fixme => "FIXME",
         };
-        let details = if self.missing_number { " without issue number" } else { "" };
+        let details = if self.missing_number {
+            " without issue number"
+        } else {
+            ""
+        };
 
         write!(fmt, "{}{}", msg, details)
     }
@@ -177,7 +181,7 @@ impl BadIssueSeeker {
                       issue: Issue,
                       mut part: NumberPart)
                       -> IssueClassification {
-        if ! issue.missing_number || c == '\n' {
+        if !issue.missing_number || c == '\n' {
             return IssueClassification::Bad(issue);
         } else if c == ')' {
             return if let NumberPart::CloseParen = part {

--- a/src/items.rs
+++ b/src/items.rs
@@ -446,7 +446,11 @@ impl<'a> FmtVisitor<'a> {
                                  + field.node.name.to_string().len()
                                  + 1; // Open paren
 
-                    let comma_cost = if self.config.enum_trailing_comma { 1 } else { 0 };
+                    let comma_cost = if self.config.enum_trailing_comma {
+                        1
+                    } else {
+                        0
+                    };
                     let budget = self.config.ideal_width - indent - comma_cost - 1; // 1 = )
 
                     let fmt = ListFormatting {
@@ -520,7 +524,11 @@ impl<'a> FmtVisitor<'a> {
             ast::StructFieldKind::UnnamedField(..) => true
         };
 
-        let (opener, terminator) = if is_tuple { ("(", ")") } else { (" {", "}") };
+        let (opener, terminator) = if is_tuple {
+            ("(", ")")
+        } else {
+            (" {", "}")
+        };
 
         let generics_str = match generics {
             Some(g) => self.format_generics(g,
@@ -565,7 +573,11 @@ impl<'a> FmtVisitor<'a> {
             result.push_str(&indentation);
         }
 
-        let tactic = if break_line { ListTactic::Vertical } else { ListTactic::Horizontal };
+        let tactic = if break_line {
+            ListTactic::Vertical
+        } else {
+            ListTactic::Horizontal
+        };
 
         // 1 = ,
         let budget = self.config.ideal_width - offset + self.config.tab_spaces - 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,11 +218,12 @@ fn fmt_lines(changes: &mut ChangeSet, config: &Config) -> FormatReport {
         let mut cur_line = 1;
         let mut newline_count = 0;
         let mut errors = vec![];
-        let mut issue_seeker = BadIssueSeeker::new(config.report_todo,
-                                                   config.report_fixme);
+        let mut issue_seeker = BadIssueSeeker::new(config.report_todo, config.report_fixme);
 
         for (c, b) in text.chars() {
-            if c == '\r' { continue; }
+            if c == '\r' {
+                continue;
+            }
 
             // Add warnings for bad todos/ fixmes
             if let Some(issue) = issue_seeker.inspect(c) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,8 @@ use visitor::FmtVisitor;
 use config::Config;
 
 #[macro_use]
-mod config;
-#[macro_use]
 mod utils;
+pub mod config;
 mod changes;
 mod visitor;
 mod items;

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -136,7 +136,11 @@ pub fn write_list<'b>(items: &[ListItem], formatting: &ListFormatting<'b>) -> St
         let first = i == 0;
         let last = i == items.len() - 1;
         let separate = !last || trailing_separator;
-        let item_sep_len = if separate { sep_len } else { 0 };
+        let item_sep_len = if separate {
+            sep_len
+        } else {
+            0
+        };
         let item_width = item.item.len() + item_sep_len;
 
         match tactic {
@@ -208,8 +212,7 @@ pub fn write_list<'b>(items: &[ListItem], formatting: &ListFormatting<'b>) -> St
             let comment = item.post_comment.as_ref().unwrap();
             // Use block-style only for the last item or multiline comments.
             let block_style = formatting.ends_with_newline && last ||
-                              comment.trim().contains('\n') ||
-                              comment.trim().len() > width;
+                              comment.trim().contains('\n') || comment.trim().len() > width;
 
             let formatted_comment = rewrite_comment(comment, block_style, width, offset);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,7 +24,9 @@ pub fn span_after(original: Span, needle: &str, codemap: &CodeMap) -> BytePos {
 
 #[inline]
 pub fn prev_char(s: &str, mut i: usize) -> usize {
-    if i == 0 { return 0; }
+    if i == 0 {
+        return 0;
+    }
 
     i -= 1;
     while !s.is_char_boundary(i) {
@@ -35,7 +37,9 @@ pub fn prev_char(s: &str, mut i: usize) -> usize {
 
 #[inline]
 pub fn next_char(s: &str, mut i: usize) -> usize {
-    if i >= s.len() { return s.len(); }
+    if i >= s.len() {
+        return s.len();
+    }
 
     while !s.is_char_boundary(i) {
         i += 1;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -353,7 +353,7 @@ impl<'a> FmtVisitor<'a> {
 
             result.push_str(&a_str);
 
-            if i < attrs.len() -1 {
+            if i < attrs.len() - 1 {
                 result.push('\n');
             }
         }

--- a/tests/config/expr_visual_indent.toml
+++ b/tests/config/expr_visual_indent.toml
@@ -13,4 +13,4 @@ enum_trailing_comma = true
 report_todo = "Always"
 report_fixme = "Never"
 reorder_imports = false
-expr_indent_style = "Tabbed"
+expr_indent_style = "Visual"

--- a/tests/config/reorder_imports.toml
+++ b/tests/config/reorder_imports.toml
@@ -13,3 +13,4 @@ enum_trailing_comma = true
 report_todo = "Always"
 report_fixme = "Never"
 reorder_imports = true
+expr_indent_style = "Tabbed"

--- a/tests/config/small_tabs.toml
+++ b/tests/config/small_tabs.toml
@@ -13,3 +13,4 @@ enum_trailing_comma = true
 report_todo = "Always"
 report_fixme = "Never"
 reorder_imports = false
+expr_indent_style = "Tabbed"

--- a/tests/config/visual_struct_lits.toml
+++ b/tests/config/visual_struct_lits.toml
@@ -13,3 +13,4 @@ enum_trailing_comma = true
 report_todo = "Always"
 report_fixme = "Never"
 reorder_imports = false
+expr_indent_style = "Tabbed"

--- a/tests/source/expr-visual-indent.rs
+++ b/tests/source/expr-visual-indent.rs
@@ -1,0 +1,9 @@
+// rustfmt-config: expr_visual_indent.toml
+
+// Visual level block indentation.
+
+fn matcher() {
+    Some(while true {
+        test();
+    })
+}

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -14,6 +14,10 @@ some_ridiculously_loooooooooooooooooooooong_function(10000 * 30000000000 + 40000
     (((((((((aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + a +
              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + aaaaa)))))))));
 
+    { for _ in 0..10 {} }
+
+    {{{{}}}}
+
      if  1  + 2 > 0  { let result = 5; result } else { 4};
 
     if  let   Some(x)  =  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
@@ -30,6 +34,10 @@ some_ridiculously_loooooooooooooooooooooong_function(10000 * 30000000000 + 40000
     if let (some_very_large,
             tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) = 1111 + 2222 {}
 
+    if let (some_very_large, tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) = 1
+ + 2 + 3 {
+    }
+
     if cond() {
         something();
     } else  if different_cond() {
@@ -38,4 +46,20 @@ some_ridiculously_loooooooooooooooooooooong_function(10000 * 30000000000 + 40000
         // Check subformatting
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     }
+}
+
+fn bar() {
+    let range = (   111111111 + 333333333333333333 + 1111 +   400000000000000000) .. (2222 +  2333333333333333);
+
+    let another_range = 5..some_func( a , b /* comment */);
+
+    for _  in  1 ..{ call_forever(); }
+
+    syntactically_correct(loop { sup( '?'); }, if cond { 0 } else { 1 });
+
+    let third = ..10;
+    let infi_range = ..;
+    let foo = 1..;
+    let bar = 5;
+    let nonsense = (10 .. 0)..(0..10);
 }

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -16,6 +16,20 @@ some_ridiculously_loooooooooooooooooooooong_function(10000 * 30000000000 + 40000
 
      if  1  + 2 > 0  { let result = 5; result } else { 4};
 
+    if  let   Some(x)  =  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
+        // Nothing
+    }
+
+    if  let   Some(x)  =  (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) {}
+
+    if let (some_very_large,
+            tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) = 1
+        + 2 + 3 {
+    }
+
+    if let (some_very_large,
+            tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) = 1111 + 2222 {}
+
     if cond() {
         something();
     } else  if different_cond() {

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -12,5 +12,16 @@ some_ridiculously_loooooooooooooooooooooong_function(10000 * 30000000000 + 40000
                                                      - 50000 * sqrt(-1),
                                                      trivial_value);
     (((((((((aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + a +
-             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + aaaaa)))))))))
+             aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + aaaaa)))))))));
+
+     if  1  + 2 > 0  { let result = 5; result } else { 4};
+
+    if cond() {
+        something();
+    } else  if different_cond() {
+        something_else();
+    } else {
+        // Check subformatting
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    }
 }

--- a/tests/source/loop.rs
+++ b/tests/source/loop.rs
@@ -5,7 +5,12 @@ fn main() {
 
 let x = loop { do_forever(); };
 
-         loop {
+       'label :  loop {
         // Just comments
     }
+
+    'a: while loooooooooooooooooooooooooooooooooong_variable_name + another_value > some_other_value{}
+
+   while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa > bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {
+   }
 }

--- a/tests/source/loop.rs
+++ b/tests/source/loop.rs
@@ -13,4 +13,13 @@ let x = loop { do_forever(); };
 
    while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa > bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {
    }
+
+    'b: for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx in some_iter(arg1, arg2) {
+        // do smth
+    }
+
+    while let  Some(i) =     x.find('s')
+    {
+        x.update();
+    }
 }

--- a/tests/source/struct_lits.rs
+++ b/tests/source/struct_lits.rs
@@ -22,6 +22,8 @@ fn main() {
     Foo { a:Bar,
           b:foo() };
 
+    Quux { x: if cond { bar(); }, y: baz() };
+
     A { 
     // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
     first: item(),
@@ -36,4 +38,13 @@ fn main() {
                *              /|\   \
                *             o o o   o */
               graph: G, }
+}
+
+fn matcher() {
+    TagTerminatedByteMatcher {
+        matcher: ByteMatcher {
+        pattern: b"<HTML",
+        mask: b"\xFF\xDF\xDF\xDF\xDF\xFF",
+    },
+    };
 }

--- a/tests/source/struct_lits_visual.rs
+++ b/tests/source/struct_lits_visual.rs
@@ -22,6 +22,8 @@ fn main() {
     Foo { a:Bar,
           b:foo() };
 
+    Quux { x: if cond { bar(); }, y: baz() };
+
     A { 
     // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
     first: item(),

--- a/tests/target/expr-visual-indent.rs
+++ b/tests/target/expr-visual-indent.rs
@@ -1,0 +1,9 @@
+// rustfmt-config: expr_visual_indent.toml
+
+// Visual level block indentation.
+
+fn matcher() {
+    Some(while true {
+             test();
+         })
+}

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -13,5 +13,22 @@ fn foo() -> bool {
                                                          trivial_value);
     (((((((((aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
              a + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
-             aaaaa)))))))))
+             aaaaa)))))))));
+
+    if 1 + 2 > 0 {
+        let result = 5;
+        result
+    } else {
+        4
+    };
+
+    if cond() {
+        something();
+    } else if different_cond() {
+        something_else();
+    } else {
+        // Check subformatting
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    }
 }

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -15,6 +15,20 @@ fn foo() -> bool {
              a + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
              aaaaa)))))))));
 
+    {
+        for _ in 0..10 {
+        }
+    }
+
+    {
+        {
+            {
+                {
+                }
+            }
+        }
+    }
+
     if 1 + 2 > 0 {
         let result = 5;
         result
@@ -39,6 +53,10 @@ fn foo() -> bool {
                                                                                          2222 {
     }
 
+    if let (some_very_large, tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) =
+           1 + 2 + 3 {
+    }
+
     if cond() {
         something();
     } else if different_cond() {
@@ -48,4 +66,30 @@ fn foo() -> bool {
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     }
+}
+
+fn bar() {
+    let range = (111111111 + 333333333333333333 + 1111 + 400000000000000000)..(2222 +
+                                                                               2333333333333333);
+
+    let another_range = 5..some_func(a, b /* comment */);
+
+    for _ in 1.. {
+        call_forever();
+    }
+
+    syntactically_correct(loop {
+            sup('?');
+        },
+                          if cond {
+            0
+        } else {
+            1
+        });
+
+    let third = ..10;
+    let infi_range = ..;
+    let foo = 1..;
+    let bar = 5;
+    let nonsense = (10..0)..(0..10);
 }

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -22,6 +22,23 @@ fn foo() -> bool {
         4
     };
 
+    if let Some(x) = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
+        // Nothing
+    }
+
+    if let Some(x) = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+                      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) {
+    }
+
+    if let (some_very_large,
+            tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) = 1 + 2 + 3 {
+    }
+
+    if let (some_very_large,
+            tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) = 1111 +
+                                                                                         2222 {
+    }
+
     if cond() {
         something();
     } else if different_cond() {

--- a/tests/target/loop.rs
+++ b/tests/target/loop.rs
@@ -8,7 +8,14 @@ fn main() {
         do_forever();
     };
 
-    loop {
+    'label: loop {
         // Just comments
+    }
+
+    'a: while loooooooooooooooooooooooooooooooooong_variable_name + another_value >
+              some_other_value {
+    }
+
+    while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa > bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {
     }
 }

--- a/tests/target/loop.rs
+++ b/tests/target/loop.rs
@@ -18,4 +18,13 @@ fn main() {
 
     while aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa > bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb {
     }
+
+    'b: for xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx in some_iter(arg1,
+                                                                                        arg2) {
+        // do smth
+    }
+
+    while let Some(i) = x.find('s') {
+        x.update();
+    }
 }

--- a/tests/target/struct_lits.rs
+++ b/tests/target/struct_lits.rs
@@ -29,9 +29,16 @@ fn main() {
 
     Foo { a: Bar, b: foo() };
 
+    Quux {
+        x: if cond {
+            bar();
+        },
+        y: baz(),
+    };
+
     A {
-        // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed
-        // sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante
+        // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit
+        // amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante
         // hendrerit. Donec et mollis dolor.
         first: item(),
         // Praesent et diam eget libero egestas mattis sit amet vitae augue.
@@ -47,4 +54,13 @@ fn main() {
         //             o o o   o
         graph: G,
     }
+}
+
+fn matcher() {
+    TagTerminatedByteMatcher {
+        matcher: ByteMatcher {
+            pattern: b"<HTML",
+            mask: b"\xFF\xDF\xDF\xDF\xDF\xFF",
+        },
+    };
 }

--- a/tests/target/struct_lits_visual.rs
+++ b/tests/target/struct_lits_visual.rs
@@ -35,6 +35,11 @@ fn main() {
 
     Foo { a: Bar, b: foo() };
 
+    Quux { x: if cond {
+               bar();
+           },
+           y: baz(), };
+
     A { // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit
         // amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante
         // hendrerit. Donec et mollis dolor.


### PR DESCRIPTION
Since a lot of code is inside these expressions, this should significantly increase coverage!

Blocked by https://github.com/rust-lang/rust/pull/27065.

Single line if-else expressions are not implemented yet.

Closes https://github.com/nrc/rustfmt/issues/102.