### PR TITLE
Features

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -25,10 +25,7 @@ fn main() {
     def_config_file.read_to_string(&mut def_config).unwrap();
     let mut def_config = config::Config::from_toml(&def_config);
 
-    // TODO remove
-    def_config.features = vec![config::Feature::Tidy];
-
-    run(args, WriteMode::Display, def_config);
+    run(args, WriteMode::Overwrite, def_config);
 
     std::process::exit(0);
 }

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -12,18 +12,23 @@
 
 extern crate rustfmt;
 
-use rustfmt::{WriteMode, run};
+use rustfmt::{WriteMode, run, config};
 
 use std::fs::File;
 use std::io::Read;
 
 fn main() {
     let args: Vec<_> = std::env::args().collect();
+
     let mut def_config_file = File::open("default.toml").unwrap();
     let mut def_config = String::new();
     def_config_file.read_to_string(&mut def_config).unwrap();
+    let mut def_config = config::Config::from_toml(&def_config);
 
-    run(args, WriteMode::Overwrite, &def_config);
+    // TODO remove
+    def_config.features = vec![config::Feature::Tidy];
+
+    run(args, WriteMode::Display, def_config);
 
     std::process::exit(0);
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ extern crate toml;
 use lists::SeparatorTactic;
 use issues::ReportTactic;
 
+use std::str::FromStr;
 
 #[derive(RustcDecodable, Clone)]
 pub struct Config {
@@ -94,7 +95,8 @@ pub enum Feature {
     Trim,
 
     FnDecls,
-    // Also covers statements and blocks.
+    // Also covers statements and blocks (and items inside blocks, which are a
+    // a kind of statement).
     Expressions,
     // Also covers trait and impl items (and imports).
     // FIXME would be good to split out imports.
@@ -104,3 +106,19 @@ pub enum Feature {
 }
 
 impl_enum_decodable!(Feature, Tidy, Trim, FnDecls, Expressions, Items, Comments);
+
+impl FromStr for Feature {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Feature, ()> {
+        match s {
+            "Tidy" => Ok(Feature::Tidy),
+            "Trim" => Ok(Feature::Trim),
+            "FnDecls" => Ok(Feature::FnDecls),
+            "Expressions" => Ok(Feature::Expressions),
+            "Items" => Ok(Feature::Items),
+            "Comments" => Ok(Feature::Comments),
+            _ => Err(())
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,19 @@ pub enum Feature {
 
 impl_enum_decodable!(Feature, Tidy, Trim, FnDecls, Expressions, Items, Comments);
 
+// How to stle a struct literal.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum StructLitStyle {
+    // First line on the same line as the opening brace, all lines aligned with
+    // the first line.
+    VisualIndent,
+    // First line is on a new line and all lines align with block indent.
+    BlockIndent,
+    // FIXME Maybe we should also have an option to align types.
+}
+
+impl_enum_decodable!(StructLitStyle, VisualIndent, BlockIndent);
+
 impl FromStr for Feature {
     type Err = ();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,9 +10,9 @@
 
 extern crate toml;
 
-use {NewlineStyle, BraceStyle, ReturnIndent, StructLitStyle};
 use lists::SeparatorTactic;
 use issues::ReportTactic;
+
 
 #[derive(RustcDecodable, Clone)]
 pub struct Config {
@@ -31,6 +31,7 @@ pub struct Config {
     pub report_todo: ReportTactic,
     pub report_fixme: ReportTactic,
     pub reorder_imports: bool, // Alphabetically, case sensitive.
+    pub features: Vec<Feature>,
 }
 
 impl Config {
@@ -46,4 +47,60 @@ impl Config {
             }
         }
     }
+
+    pub fn feature(&self, f: Feature) -> bool {
+        self.features.len() == 0 || self.features.contains(&f)
+    }
 }
+
+
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum NewlineStyle {
+    Windows, // \r\n
+    Unix, // \n
+}
+
+impl_enum_decodable!(NewlineStyle, Windows, Unix);
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum BraceStyle {
+    AlwaysNextLine,
+    PreferSameLine,
+    // Prefer same line except where there is a where clause, in which case force
+    // the brace to the next line.
+    SameLineWhere,
+}
+
+impl_enum_decodable!(BraceStyle, AlwaysNextLine, PreferSameLine, SameLineWhere);
+
+// How to indent a function's return type.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum ReturnIndent {
+    // Aligned with the arguments
+    WithArgs,
+    // Aligned with the where clause
+    WithWhereClause,
+}
+
+impl_enum_decodable!(ReturnIndent, WithArgs, WithWhereClause);
+
+// Which features to run.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum Feature {
+    // Check for overlong lines, trailing whitespace, TODOs, etc.
+    Tidy,
+    // Trim trailing whitespace.
+    Trim,
+
+    FnDecls,
+    // Also covers statements and blocks.
+    Expressions,
+    // Also covers trait and impl items (and imports).
+    // FIXME would be good to split out imports.
+    Items,
+
+    Comments,
+}
+
+impl_enum_decodable!(Feature, Tidy, Trim, FnDecls, Expressions, Items, Comments);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ use changes::ChangeSet;
 use visitor::FmtVisitor;
 use config::Config;
 
-pub use config::{NewlineStyle, BraceStyle, ReturnIndent, Feature};
+pub use config::{NewlineStyle, BraceStyle, ReturnIndent, StructLitStyle, Feature};
 
 #[macro_use]
 mod utils;
@@ -81,20 +81,6 @@ pub enum WriteMode {
     // Return the result as a mapping from filenames to StringBuffers.
     Return(&'static Fn(HashMap<String, String>)),
 }
-
-
-// How to stle a struct literal.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum StructLitStyle {
-    // First line on the same line as the opening brace, all lines aligned with
-    // the first line.
-    VisualIndent,
-    // First line is on a new line and all lines align with block indent.
-    BlockIndent,
-    // FIXME Maybe we should also have an option to align types.
-}
-
-impl_enum_decodable!(StructLitStyle, VisualIndent, BlockIndent);
 
 enum ErrorKind {
     // Line has exceeded character limit

--- a/tests/source/hello2.rs
+++ b/tests/source/hello2.rs
@@ -6,3 +6,9 @@
 fn main( ) {
 println!("Hello world!");
 }
+
+
+
+
+
+

--- a/tests/source/hello3.rs
+++ b/tests/source/hello3.rs
@@ -1,0 +1,15 @@
+// rustfmt-config: small_tabs.toml
+// rustfmt-target: hello3.rs
+// rustfmt-features: Trim
+
+// Smoke test - should just trim whitespace.
+
+fn main( ) {
+println!("Hello world!");   
+}
+
+
+
+
+
+

--- a/tests/source/imports.rs
+++ b/tests/source/imports.rs
@@ -1,4 +1,4 @@
-// Imports.
+// rustfmt-features: Items, Trim, Expressions
 
 // Long import.
 use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};

--- a/tests/target/fn_decl_only.rs
+++ b/tests/target/fn_decl_only.rs
@@ -1,5 +1,5 @@
-// rustfmt-features: Trim, Items, FnDecls, Expressions
-// Tests different fns
+// rustfmt-features: Trim, FnDecls
+// Test that fn decl formatting works with just that feature.
 
 fn foo(a: AAAA, b: BBB, c: CCC) -> RetType {
 
@@ -15,25 +15,27 @@ fn foo(a: AAA /* (comment) */)
     where T: Blah
 {
 
-}
 
-fn foo(a: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
-       b: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB)
-       -> RetType
-    where T: Blah
-{
 
 }
 
-
-fn foo<U, T>(a: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+      fn foo(a: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
              b: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB)
              -> RetType
-    where T: Blah,
-          U: dsfasdfasdfasd
-{
+          where T: Blah
+      {
 
-}
+      }
+
+
+  fn foo<U, T>(a: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+               b: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB)
+               -> RetType
+      where T: Blah,
+            U: dsfasdfasdfasd
+  {
+
+  }
 
 fn foo<U: Fn(A) -> B /* paren inside generics */>() {
 }
@@ -59,7 +61,7 @@ pub fn render<'a,
     (g: &'a G,
      w: &mut W)
      -> io::Result<()> {
-    render_opts(g, w, &[])
+  render_opts(g, w, &[])
 }
 
 const fn foo() {
@@ -77,6 +79,7 @@ impl Foo {
 }
 
 fn main() {
-    let _ = function(move || 5);
-    let _ = move || 42;
+    let _ =   foo ();
+  let _ =
+    whatever.  bar(    );
 }

--- a/tests/target/hello3.rs
+++ b/tests/target/hello3.rs
@@ -1,0 +1,9 @@
+// rustfmt-config: small_tabs.toml
+// rustfmt-target: hello3.rs
+// rustfmt-features: Trim
+
+// Smoke test - should just trim whitespace.
+
+fn main( ) {
+println!("Hello world!");
+}

--- a/tests/target/imports.rs
+++ b/tests/target/imports.rs
@@ -1,4 +1,4 @@
-// Imports.
+// rustfmt-features: Items, Trim, Expressions
 
 // Long import.
 use syntax::ast::{ItemForeignMod, ItemImpl, ItemMac, ItemMod, ItemStatic, ItemDefaultImpl};


### PR DESCRIPTION
The idea here is that you can define in the config file which features Rustfmt will use when formatting your files, thus avoiding using any feature which is unstable or controversial.

No feature string => use everything.

r? @marcusklaas, @cassiersg 

This is far from perfect. I'm not sure it can ever be perfect, and probably not without a big refactoring. This is probably necessary for adoption though. I hope that as we focus on each particular feature, we can put some effort into making it work properly. So far, I have tried to make the following subsets work well: Tidy; Tidy, Trim; Tidy, Trim, FnDecls. The rest is probably a bit wonky.

There's a bit of basic refactoring here too - mostly moving things around, I should have made it a separate commit, but this took *ages* and I've run out of energy.