### PR TITLE
Fix underflow bug in rewrite_call

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -132,7 +132,7 @@ fn rewrite_call(context: &RewriteContext,
     }
 
     // 2 is for parens.
-    let remaining_width = width - callee_str.len() - 2;
+    let remaining_width = try_opt!(width.checked_sub(callee_str.len() + 2));
     let offset = callee_str.len() + 1 + offset;
 
     let items = itemize_list(context.codemap,

--- a/tests/target/fn.rs
+++ b/tests/target/fn.rs
@@ -79,3 +79,17 @@ fn main() {
     let _ = function(move || 5);
     let _ = move || 42;
 }
+
+fn servo() {
+    let constellation_chan = Constellation::<layout::layout_task::LayoutTask,
+    script::script_task::ScriptTask>::start(
+        compositor_proxy,
+        resource_task,
+        image_cache_task,
+        font_cache_task,
+        time_profiler_chan,
+        mem_profiler_chan,
+        devtools_chan,
+        storage_task,
+        supports_clipboard);
+}


### PR DESCRIPTION
Closes https://github.com/nrc/rustfmt/issues/148. Rustfmt should be able to run on servo with this fix.

It now properly propagates the rewrite failure instead of panicking. Added regression test from servo code. 

This example will be properly rewritten when https://github.com/nrc/rustfmt/issues/17 is fixed. I'm working on that.