### PR TITLE
Correctly format typed self in function arguments

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -64,6 +64,14 @@ pub fn format_visibility(vis: Visibility) -> &'static str {
     }
 }
 
+#[inline]
+pub fn format_mutability(mutability: ast::Mutability) -> &'static str {
+    match mutability {
+        ast::Mutability::MutMutable => "mut ",
+        ast::Mutability::MutImmutable => ""
+    }
+}
+
 fn is_skip(meta_item: &MetaItem) -> bool {
     match meta_item.node {
         MetaItem_::MetaWord(ref s) => *s == SKIP_ANNOTATION,

--- a/tests/target/trait.rs
+++ b/tests/target/trait.rs
@@ -22,3 +22,7 @@ trait Foo {
 pub trait WriteMessage {
     fn write_message(&mut self, &FrontendMessage) -> io::Result<()>;
 }
+
+trait Runnable {
+    fn handler(self: &Runnable);
+}


### PR DESCRIPTION
This closes https://github.com/nrc/rustfmt/issues/153.