### PR TITLE
Properly format unsafe blocks

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -73,7 +73,6 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
         debug!("visit_block: {:?} {:?}",
                self.codemap.lookup_char_pos(b.span.lo),
                self.codemap.lookup_char_pos(b.span.hi));
-        self.format_missing(b.span.lo);
 
         self.changes.push_str_span(b.span, "{");
         self.last_pos = self.last_pos + BytePos(1);
@@ -82,6 +81,7 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
         for stmt in &b.stmts {
             self.visit_stmt(&stmt)
         }
+
         match b.expr {
             Some(ref e) => {
                 self.format_missing_with_indent(e.span.lo);

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -73,3 +73,21 @@ fn bar() {
              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
              a);
 }
+
+fn baz() {
+    unsafe    /*    {}{}{}{{{{}}   */   {
+        let foo = 1u32;
+    }
+
+    unsafe /* very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong comment */ {}
+
+    unsafe // So this is a very long comment.
+           // Multi-line, too.
+           // Will it still format correctly?
+    {
+    }
+
+    unsafe {
+        // Regular unsafe block
+    }
+}

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -102,3 +102,22 @@ fn bar() {
     let x = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa && aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
              a);
 }
+
+fn baz() {
+    unsafe /* {}{}{}{{{{}} */ {
+        let foo = 1u32;
+    }
+
+    unsafe /* very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+            * comment */ {
+    }
+
+    unsafe /* So this is a very long comment.
+            * Multi-line, too.
+            * Will it still format correctly? */ {
+    }
+
+    unsafe {
+        // Regular unsafe block
+    }
+}


### PR DESCRIPTION
This mostly fixes https://github.com/nrc/rustfmt/issues/166. The leading blank line seems to be a different issue.