### PR TITLE
Refactor itemize list so that it produces an iterator

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -407,9 +407,7 @@ fn rewrite_call(context: &RewriteContext,
     let inner_context = &RewriteContext { block_indent: block_indent, ..*context };
 
     let items = itemize_list(context.codemap,
-                             Vec::new(),
                              args.iter(),
-                             ",",
                              ")",
                              |item| item.span.lo,
                              |item| item.span.hi,
@@ -430,7 +428,7 @@ fn rewrite_call(context: &RewriteContext,
         ends_with_newline: false,
     };
 
-    Some(format!("{}({})", callee_str, write_list(&items, &fmt)))
+    Some(format!("{}({})", callee_str, write_list(&items.collect::<Vec<_>>(), &fmt)))
 }
 
 fn expr_block_indent(context: &RewriteContext, offset: usize) -> usize {
@@ -494,9 +492,7 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
     let inner_context = &RewriteContext { block_indent: indent, ..*context };
 
     let items = itemize_list(context.codemap,
-                             Vec::new(),
                              field_iter,
-                             ",",
                              "}",
                              |item| {
                                  match *item {
@@ -543,7 +539,7 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
         v_width: v_budget,
         ends_with_newline: false,
     };
-    let fields_str = write_list(&items, &fmt);
+    let fields_str = write_list(&items.collect::<Vec<_>>(), &fmt);
 
     match context.config.struct_lit_style {
         StructLitStyle::BlockIndent if fields_str.contains('\n') => {
@@ -584,9 +580,7 @@ fn rewrite_tuple_lit(context: &RewriteContext,
     }
 
     let items = itemize_list(context.codemap,
-                             Vec::new(),
-                             items.into_iter(),
-                             ",",
+                             items.iter(),
                              ")",
                              |item| item.span.lo,
                              |item| item.span.hi,
@@ -608,7 +602,7 @@ fn rewrite_tuple_lit(context: &RewriteContext,
         ends_with_newline: false,
     };
 
-    Some(format!("({})", write_list(&items, &fmt)))
+    Some(format!("({})", write_list(&items.collect::<Vec<_>>(), &fmt)))
 }
 
 fn rewrite_binary_op(context: &RewriteContext,

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -108,30 +108,33 @@ pub fn rewrite_use_list(width: usize,
         ends_with_newline: false,
     };
 
-    let mut items = itemize_list(context.codemap,
-                                 vec![ListItem::from_str("")], /* Dummy value, explanation
-                                                                * below */
-                                 path_list.iter(),
-                                 ",",
-                                 "}",
-                                 |vpi| vpi.span.lo,
-                                 |vpi| vpi.span.hi,
-                                 |vpi| match vpi.node {
+    let mut items = {
+        // Dummy value, see explanation below.
+        let mut items = vec![ListItem::from_str("")];
+        let iter = itemize_list(context.codemap,
+                                path_list.iter(),
+                                "}",
+                                |vpi| vpi.span.lo,
+                                |vpi| vpi.span.hi,
+                                |vpi| match vpi.node {
                                      ast::PathListItem_::PathListIdent{ name, .. } => {
                                          name.to_string()
                                      }
                                      ast::PathListItem_::PathListMod{ .. } => {
                                          "self".to_owned()
                                      }
-                                 },
-                                 span_after(span, "{", context.codemap),
-                                 span.hi);
+                                },
+                                span_after(span, "{", context.codemap),
+                                span.hi);
+        items.extend(iter);
+        items
+    };
 
     // We prefixed the item list with a dummy value so that we can
     // potentially move "self" to the front of the vector without touching
     // the rest of the items.
-    // FIXME: Make more efficient by using a linked list? That would
-    // require changes to the signatures of itemize_list and write_list.
+    // FIXME: Make more efficient by using a linked list? That would require
+    // changes to the signatures of write_list.
     let has_self = move_self_to_front(&mut items);
     let first_index = if has_self {
         0

--- a/src/types.rs
+++ b/src/types.rs
@@ -204,9 +204,7 @@ fn rewrite_segment(segment: &ast::PathSegment,
             let separator = get_path_separator(context.codemap, *span_lo, list_lo);
 
             let items = itemize_list(context.codemap,
-                                     Vec::new(),
                                      param_list.into_iter(),
-                                     ",",
                                      ">",
                                      |param| param.get_span().lo,
                                      |param| param.get_span().hi,
@@ -232,7 +230,7 @@ fn rewrite_segment(segment: &ast::PathSegment,
             // update pos
             *span_lo = next_span_lo;
 
-            format!("{}<{}>", separator, write_list(&items, &fmt))
+            format!("{}<{}>", separator, write_list(&items.collect::<Vec<_>>(), &fmt))
         }
         ast::PathParameters::ParenthesizedParameters(ref data) => {
             let output = match data.output {
@@ -242,9 +240,7 @@ fn rewrite_segment(segment: &ast::PathSegment,
 
             let list_lo = span_after(codemap::mk_sp(*span_lo, span_hi), "(", context.codemap);
             let items = itemize_list(context.codemap,
-                                     Vec::new(),
                                      data.inputs.iter(),
-                                     ",",
                                      ")",
                                      |ty| ty.span.lo,
                                      |ty| ty.span.hi,
@@ -269,7 +265,7 @@ fn rewrite_segment(segment: &ast::PathSegment,
             // update pos
             *span_lo = data.inputs.last().unwrap().span.hi + BytePos(1);
 
-            format!("({}){}", write_list(&items, &fmt), output)
+            format!("({}){}", write_list(&items.collect::<Vec<_>>(), &fmt), output)
         }
         _ => String::new()
     };


### PR DESCRIPTION
This enables us to itemize lists without allocating. We currently need still need a vector in order to use `write_list`, but when https://github.com/nrc/rustfmt/issues/133 is addressed, that may not be necessary any more.