### PR TITLE
Remove faulty shortcut in `rewrite_string_lit`

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -354,7 +354,7 @@ mod test {
         check("/* comment */ some text /* more commentary */ result", "result", Some(46));
         check("sup // sup", "p", Some(2));
         check("sup", "x", None);
-        check("π? /**/ π is nice!", "π is nice", Some(9));
+        check(r#"π? /**/ π is nice!"#, r#"π is nice"#, Some(9));
         check("/*sup yo? \n sup*/ sup", "p", Some(20));
         check("hel/*lohello*/lo", "hello", None);
         check("acb", "ab", None);

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -20,7 +20,7 @@ use types::rewrite_path;
 use items::{span_lo_for_arg, span_hi_for_arg, rewrite_fn_input};
 
 use syntax::{ast, ptr};
-use syntax::codemap::{CodeMap, Pos, Span, BytePos, mk_sp};
+use syntax::codemap::{CodeMap, Span, BytePos, mk_sp};
 use syntax::visit::Visitor;
 
 impl Rewrite for ast::Expr {
@@ -831,13 +831,7 @@ fn rewrite_string_lit(context: &RewriteContext,
     if context.config.format_strings == false {
         return Some(context.snippet(span));
     }
-    // Check if there is anything to fix: we always try to fixup multi-line
-    // strings, or if the string is too long for the line.
-    let l_loc = context.codemap.lookup_char_pos(span.lo);
-    let r_loc = context.codemap.lookup_char_pos(span.hi);
-    if l_loc.line == r_loc.line && r_loc.col.to_usize() <= context.config.max_width {
-        return Some(context.snippet(span));
-    }
+
     let fmt = StringFormat {
         opener: "\"",
         closer: "\"",

--- a/tests/source/string-lit.rs
+++ b/tests/source/string-lit.rs
@@ -22,5 +22,8 @@ not
 remove
 formatting"#;
 
+    let xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx =
+        funktion("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy");
+
     "stuff"
 }

--- a/tests/target/string-lit.rs
+++ b/tests/target/string-lit.rs
@@ -25,5 +25,10 @@ not
 remove
 formatting"#;
 
+    let xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx = funktion("yyyyyyyyyyyyyyyyyyyyy\
+                                                                            yyyyyyyyyyyyyyyyyyyyy\
+                                                                            yyyyyyyyyyyyyyyyyyyyy\
+                                                                            yyyyyyyyyy");
+
     "stuff"
 }


### PR DESCRIPTION
Rustfmt would leave the literal unchanged when it did not exceed the column limit in its original position, not considering its position after formatting.