### PR TITLE
Add regression test for trait reference formatting

### DIFF
--- a/tests/source/fn-simple.rs
+++ b/tests/source/fn-simple.rs
@@ -17,3 +17,5 @@ fn generic<T>(arg: T) -> &SomeType
         B, C, D, /* pre comment */ E /* last comment */) -> &SomeType {
     arg(a, b, c, d, e)    
 }
+
+fn some_func<T:Box<Trait+Bound>>(val:T){}

--- a/tests/target/fn-simple.rs
+++ b/tests/target/fn-simple.rs
@@ -27,3 +27,6 @@ fn generic<T>(arg: T) -> &SomeType
 {
     arg(a, b, c, d, e)
 }
+
+fn some_func<T: Box<Trait + Bound>>(val: T) {
+}


### PR DESCRIPTION
The PR https://github.com/nrc/rustfmt/pull/246 includes a similar test. Here, both bounds are trait bounds.

Closes https://github.com/nrc/rustfmt/issues/152.