### PR TITLE
code improvements suggested by clippy

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -81,7 +81,7 @@ pub fn rewrite_comment(orig: &str, block_style: bool, width: usize, offset: usiz
     s
 }
 
-fn left_trim_comment_line<'a>(line: &'a str) -> &'a str {
+fn left_trim_comment_line(line: &str) -> &str {
     if line.starts_with("/* ") || line.starts_with("// ") {
         &line[3..]
     } else if line.starts_with("/*") || line.starts_with("* ") || line.starts_with("//") {
@@ -289,7 +289,7 @@ impl<T> Iterator for CharClasses<T> where T: Iterator, T::Item: RichChar {
                 return Some((CodeCharKind::Comment, item));
             }
         };
-        return Some((CodeCharKind::Normal, item));
+        Some((CodeCharKind::Normal, item))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ struct FormatReport {
 impl fmt::Display for FormatReport {
     // Prints all the formatting errors.
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        for (file, errors) in self.file_error_map.iter() {
+        for (file, errors) in &self.file_error_map {
             for error in errors {
                 try!(write!(fmt,
                             "{} {}:{}: {} {}\n",
@@ -292,7 +292,7 @@ fn fmt_lines(file_map: &mut FileMap, config: &Config) -> FormatReport {
             truncate_todo.push((f.to_owned(), text.len - newline_count + 1))
         }
 
-        for &(l, _, _) in trims.iter() {
+        for &(l, _, _) in &trims {
             errors.push(FormattingError {
                 line: l,
                 kind: ErrorKind::TrailingWhitespace

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -414,8 +414,8 @@ fn total_item_width(item: &ListItem) -> usize {
 }
 
 fn comment_len(comment: &Option<String>) -> usize {
-    match comment {
-        &Some(ref s) => {
+    match *comment {
+        Some(ref s) => {
             let text_len = s.trim().len();
             if text_len > 0 {
                 // We'll put " /*" before and " */" after inline comments.
@@ -424,6 +424,6 @@ fn comment_len(comment: &Option<String>) -> usize {
                 text_len
             }
         }
-        &None => 0,
+        None => 0,
     }
 }

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -36,7 +36,7 @@ fn list_submodules<'a>(module: &'a ast::Mod,
                        codemap: &codemap::CodeMap,
                        result: &mut HashMap<PathBuf, &'a ast::Mod>) {
     debug!("list_submodules: search_dir: {:?}", search_dir);
-    for item in module.items.iter() {
+    for item in &module.items {
         if let ast::ItemMod(ref sub_mod) = item.node {
             if !utils::contains_skip(&item.attrs) {
                 let is_internal = codemap.span_to_filename(item.span) ==

--- a/src/types.rs
+++ b/src/types.rs
@@ -265,8 +265,8 @@ impl Rewrite for ast::WherePredicate {
     fn rewrite(&self, context: &RewriteContext, width: usize, offset: usize) -> Option<String> {
         // TODO dead spans?
         // TODO assumes we'll always fit on one line...
-        Some(match self {
-                &ast::WherePredicate::BoundPredicate(ast::WhereBoundPredicate{ref bound_lifetimes,
+        Some(match *self {
+                ast::WherePredicate::BoundPredicate(ast::WhereBoundPredicate{ref bound_lifetimes,
                                                                           ref bounded_ty,
                                                                           ref bounds,
                                                                           ..}) => {
@@ -299,7 +299,7 @@ impl Rewrite for ast::WherePredicate {
                         format!("{}: {}", type_str, bounds_str)
                     }
                 }
-                &ast::WherePredicate::RegionPredicate(ast::WhereRegionPredicate{ref lifetime,
+                ast::WherePredicate::RegionPredicate(ast::WhereRegionPredicate{ref lifetime,
                                                                             ref bounds,
                                                                             ..}) => {
                     format!("{}: {}",
@@ -307,7 +307,7 @@ impl Rewrite for ast::WherePredicate {
                         bounds.iter().map(pprust::lifetime_to_string)
                               .collect::<Vec<_>>().join(" + "))
                 }
-                &ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ref path, ref ty, ..}) => {
+                ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ref path, ref ty, ..}) => {
                     let ty_str = pprust::ty_to_string(ty);
                 // 3 = " = ".len()
                     let used_width = 3 + ty_str.len();

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -49,10 +49,10 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
     fn visit_stmt(&mut self, stmt: &'v ast::Stmt) {
         match stmt.node {
             ast::Stmt_::StmtDecl(ref decl, _) => {
-                return match decl.node {
+                match decl.node {
                     ast::Decl_::DeclLocal(ref local) => self.visit_let(local, stmt.span),
                     ast::Decl_::DeclItem(..) => visit::walk_stmt(self, stmt),
-                };
+                }
             }
             ast::Stmt_::StmtExpr(ref ex, _) | ast::Stmt_::StmtSemi(ref ex, _) => {
                 self.format_missing_with_indent(stmt.span.lo);


### PR DESCRIPTION
Removed a few needless returns, replaced .iter()s by slice refs, and de-referenced some matches.

Yay for readabiltiy. :smile: