### PR TITLE
Initial implementation of hard tab indentation.

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -21,7 +21,7 @@
 
 use Indent;
 use rewrite::{Rewrite, RewriteContext};
-use utils::{first_line_width, make_indent};
+use utils::first_line_width;
 use expr::rewrite_call;
 
 use syntax::{ast, ptr};
@@ -117,7 +117,7 @@ pub fn rewrite_chain(mut expr: &ast::Expr,
     let connector = if fits_single_line {
         String::new()
     } else {
-        format!("\n{}", make_indent(indent, context.config))
+        format!("\n{}", indent.to_string(context.config))
     };
 
     let first_connector = if extend {

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -19,6 +19,7 @@
 // we put each subexpression on a separate, much like the (default) function
 // argument function argument strategy.
 
+use Indent;
 use rewrite::{Rewrite, RewriteContext};
 use utils::{first_line_width, make_indent};
 use expr::rewrite_call;
@@ -30,7 +31,7 @@ use syntax::print::pprust;
 pub fn rewrite_chain(mut expr: &ast::Expr,
                      context: &RewriteContext,
                      width: usize,
-                     offset: usize)
+                     offset: Indent)
                      -> Option<String> {
     let total_span = expr.span;
     let mut subexpr_list = vec![expr];
@@ -116,7 +117,7 @@ pub fn rewrite_chain(mut expr: &ast::Expr,
     let connector = if fits_single_line {
         String::new()
     } else {
-        format!("\n{}", make_indent(indent))
+        format!("\n{}", make_indent(indent, context.config))
     };
 
     let first_connector = if extend {
@@ -145,7 +146,7 @@ fn rewrite_chain_expr(expr: &ast::Expr,
                       span: Span,
                       context: &RewriteContext,
                       width: usize,
-                      offset: usize)
+                      offset: Indent)
                       -> Option<String> {
     match expr.node {
         ast::Expr_::ExprMethodCall(ref method_name, ref types, ref expressions) => {
@@ -179,7 +180,7 @@ fn rewrite_method_call(method_name: ast::Ident,
                        span: Span,
                        context: &RewriteContext,
                        width: usize,
-                       offset: usize)
+                       offset: Indent)
                        -> Option<String> {
     let type_str = if types.is_empty() {
         String::new()

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -15,7 +15,6 @@ use std::iter;
 use Indent;
 use config::Config;
 use string::{StringFormat, rewrite_string};
-use utils::make_indent;
 
 pub fn rewrite_comment(orig: &str,
                        block_style: bool,
@@ -45,7 +44,7 @@ pub fn rewrite_comment(orig: &str,
         config: config,
     };
 
-    let indent_str = make_indent(offset, config);
+    let indent_str = offset.to_string(config);
     let line_breaks = s.chars().filter(|&c| c == '\n').count();
 
     let (_, mut s) = s.lines()
@@ -304,7 +303,7 @@ mod test {
         assert_eq!("/* test */", rewrite_comment(" //test", true, 100, Indent::new(0, 100),
                                                  &config));
         assert_eq!("// comment\n// on a", rewrite_comment("// comment on a", false, 10,
-                                                          Indent::new(0, 0), &config));
+                                                          Indent::empty(), &config));
 
         assert_eq!("//  A multi line comment\n            // between args.",
                    rewrite_comment("//  A multi line comment\n             // between args.",

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -12,10 +12,17 @@
 
 use std::iter;
 
+use Indent;
+use config::Config;
 use string::{StringFormat, rewrite_string};
 use utils::make_indent;
 
-pub fn rewrite_comment(orig: &str, block_style: bool, width: usize, offset: usize) -> String {
+pub fn rewrite_comment(orig: &str,
+                       block_style: bool,
+                       width: usize,
+                       offset: Indent,
+                       config: &Config)
+                       -> String {
     let s = orig.trim();
 
     // Edge case: block comments. Let's not trim their lines (for now).
@@ -33,11 +40,12 @@ pub fn rewrite_comment(orig: &str, block_style: bool, width: usize, offset: usiz
         line_start: line_start,
         line_end: "",
         width: max_chars,
-        offset: offset + opener.len() - line_start.len(),
+        offset: offset + (opener.len() - line_start.len()),
         trim_end: true,
+        config: config,
     };
 
-    let indent_str = make_indent(offset);
+    let indent_str = make_indent(offset, config);
     let line_breaks = s.chars().filter(|&c| c == '\n').count();
 
     let (_, mut s) = s.lines()
@@ -288,27 +296,32 @@ impl<T> Iterator for CharClasses<T> where T: Iterator, T::Item: RichChar {
 mod test {
     use super::{CharClasses, CodeCharKind, contains_comment, rewrite_comment, FindUncommented};
 
-    // FIXME(#217): prevent string literal from going over the limit.
+    use Indent;
     #[test]
     #[rustfmt_skip]
     fn format_comments() {
-        assert_eq!("/* test */", rewrite_comment(" //test", true, 100, 100));
-        assert_eq!("// comment\n// on a", rewrite_comment("// comment on a", false, 10, 0));
+        let config = Default::default();
+        assert_eq!("/* test */", rewrite_comment(" //test", true, 100, Indent::new(0, 100),
+                                                 &config));
+        assert_eq!("// comment\n// on a", rewrite_comment("// comment on a", false, 10,
+                                                          Indent::new(0, 0), &config));
 
         assert_eq!("//  A multi line comment\n            // between args.",
                    rewrite_comment("//  A multi line comment\n             // between args.",
                                    false,
                                    60,
-                                   12));
+                                   Indent::new(0, 12),
+                                   &config));
 
         let input = "// comment";
         let expected =
             "/* com\n                                                                      \
              * men\n                                                                      \
              * t */";
-        assert_eq!(expected, rewrite_comment(input, true, 9, 69));
+        assert_eq!(expected, rewrite_comment(input, true, 9, Indent::new(0, 69), &config));
 
-        assert_eq!("/* trimmed */", rewrite_comment("/*   trimmed    */", true, 100, 100));
+        assert_eq!("/* trimmed */", rewrite_comment("/*   trimmed    */", true, 100,
+                                                    Indent::new(0, 100), &config));
     }
 
     // This is probably intended to be a non-test fn, but it is not used. I'm

--- a/src/config.rs
+++ b/src/config.rs
@@ -246,6 +246,7 @@ create_config! {
     format_strings: bool, "Format string literals, or leave as is",
     chains_overflow_last: bool, "Allow last call in method chain to break the line",
     take_source_hints: bool, "Retain some formatting characteristics from the source code",
+    hard_tabs: bool, "Use tab characters for indentation, spaces for alignment",
 }
 
 impl Default for Config {
@@ -279,6 +280,7 @@ impl Default for Config {
             format_strings: true,
             chains_overflow_last: true,
             take_source_hints: true,
+            hard_tabs: false,
         }
     }
 }

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use Indent;
 use lists::{write_list, itemize_list, ListItem, ListFormatting, SeparatorTactic, ListTactic};
 use utils::span_after;
 use rewrite::{Rewrite, RewriteContext};
@@ -20,7 +21,7 @@ use syntax::codemap::Span;
 
 impl Rewrite for ast::ViewPath {
     // Returns an empty string when the ViewPath is empty (like foo::bar::{})
-    fn rewrite(&self, context: &RewriteContext, width: usize, offset: usize) -> Option<String> {
+    fn rewrite(&self, context: &RewriteContext, width: usize, offset: Indent) -> Option<String> {
         match self.node {
             ast::ViewPath_::ViewPathList(_, ref path_list) if path_list.is_empty() => {
                 Some(String::new())
@@ -68,7 +69,7 @@ fn rewrite_single_use_list(path_str: String, vpi: ast::PathListItem) -> String {
 // Pretty prints a multi-item import.
 // Assumes that path_list.len() > 0.
 pub fn rewrite_use_list(width: usize,
-                        offset: usize,
+                        offset: Indent,
                         path: &ast::Path,
                         path_list: &[ast::PathListItem],
                         span: Span,
@@ -105,6 +106,7 @@ pub fn rewrite_use_list(width: usize,
         // (loose 1 column (";"))
         v_width: remaining_width,
         ends_with_newline: false,
+        config: context.config,
     };
 
     let mut items = {

--- a/src/items.rs
+++ b/src/items.rs
@@ -26,7 +26,7 @@ use syntax::parse::token;
 
 impl<'a> FmtVisitor<'a> {
     pub fn visit_let(&mut self, local: &ast::Local, span: Span) {
-        self.format_missing_with_indent(span.lo, self.config);
+        self.format_missing_with_indent(span.lo);
 
         // String that is placed within the assignment pattern and expression.
         let infix = {
@@ -497,8 +497,7 @@ impl<'a> FmtVisitor<'a> {
         }
         self.block_indent = self.block_indent.block_unindent(self.config);
 
-        self.format_missing_with_indent(span.lo + BytePos(enum_snippet.rfind('}').unwrap() as u32),
-                                        self.config);
+        self.format_missing_with_indent(span.lo + BytePos(enum_snippet.rfind('}').unwrap() as u32));
         self.buffer.push_str("}");
     }
 
@@ -508,7 +507,7 @@ impl<'a> FmtVisitor<'a> {
             return;
         }
 
-        self.format_missing_with_indent(field.span.lo, self.config);
+        self.format_missing_with_indent(field.span.lo);
 
         let result = match field.node.kind {
             ast::VariantKind::TupleVariantKind(ref types) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,10 @@ const SKIP_ANNOTATION: &'static str = "rustfmt_skip";
 
 #[derive(Copy, Clone, Debug)]
 pub struct Indent {
+    // Width of the block indent, in characters. Must be a multiple of
+    // Config::tab_spaces.
     block_indent: usize,
+    // Alignment in characters.
     alignment: usize,
 }
 
@@ -92,13 +95,17 @@ impl Indent {
         Indent { block_indent: block_indent, alignment: alignment }
     }
 
-    pub fn block_indent(mut self, block_indent: usize) -> Indent {
-        self.block_indent += block_indent;
+    pub fn empty() -> Indent {
+        Indent::new(0, 0)
+    }
+
+    pub fn block_indent(mut self, config: &Config) -> Indent {
+        self.block_indent += config.tab_spaces;
         self
     }
 
-    pub fn block_unindent(mut self, block_indent: usize) -> Indent {
-        self.block_indent -= block_indent;
+    pub fn block_unindent(mut self, config: &Config) -> Indent {
+        self.block_indent -= config.tab_spaces;
         self
     }
 
@@ -139,10 +146,7 @@ impl Sub for Indent {
     type Output = Indent;
 
     fn sub(self, rhs: Indent) -> Indent {
-        Indent {
-            block_indent: self.block_indent - rhs.block_indent,
-            alignment: self.alignment - rhs.alignment,
-        }
+        Indent::new(self.block_indent - rhs.block_indent, self.alignment - rhs.alignment)
     }
 }
 
@@ -150,7 +154,7 @@ impl Add<usize> for Indent {
     type Output = Indent;
 
     fn add(self, rhs: usize) -> Indent {
-        Indent { block_indent: self.block_indent, alignment: self.alignment + rhs }
+        Indent::new(self.block_indent, self.alignment + rhs)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ use syntax::ast;
 use syntax::codemap::CodeMap;
 use syntax::diagnostics;
 
+use std::ops::{Add, Sub};
 use std::path::PathBuf;
 use std::collections::HashMap;
 use std::fmt;
@@ -79,6 +80,79 @@ mod macros;
 const MIN_STRING: usize = 10;
 // When we get scoped annotations, we should have rustfmt::skip.
 const SKIP_ANNOTATION: &'static str = "rustfmt_skip";
+
+#[derive(Copy, Clone, Debug)]
+pub struct Indent {
+    block_indent: usize,
+    alignment: usize,
+}
+
+impl Indent {
+    pub fn new(block_indent: usize, alignment: usize) -> Indent {
+        Indent { block_indent: block_indent, alignment: alignment }
+    }
+
+    pub fn block_indent(mut self, block_indent: usize) -> Indent {
+        self.block_indent += block_indent;
+        self
+    }
+
+    pub fn block_unindent(mut self, block_indent: usize) -> Indent {
+        self.block_indent -= block_indent;
+        self
+    }
+
+    pub fn width(&self) -> usize {
+        self.block_indent + self.alignment
+    }
+
+    pub fn to_string(&self, config: &Config) -> String {
+        let (num_tabs, num_spaces) = if config.hard_tabs {
+            (self.block_indent / config.tab_spaces, self.alignment)
+        } else {
+            (0, self.block_indent + self.alignment)
+        };
+        let num_chars = num_tabs + num_spaces;
+        let mut indent = String::with_capacity(num_chars);
+        for _ in 0..num_tabs {
+            indent.push('\t')
+        }
+        for _ in 0..num_spaces {
+            indent.push(' ')
+        }
+        indent
+    }
+}
+
+impl Add for Indent {
+    type Output = Indent;
+
+    fn add(self, rhs: Indent) -> Indent {
+        Indent {
+            block_indent: self.block_indent + rhs.block_indent,
+            alignment: self.alignment + rhs.alignment,
+        }
+    }
+}
+
+impl Sub for Indent {
+    type Output = Indent;
+
+    fn sub(self, rhs: Indent) -> Indent {
+        Indent {
+            block_indent: self.block_indent - rhs.block_indent,
+            alignment: self.alignment - rhs.alignment,
+        }
+    }
+}
+
+impl Add<usize> for Indent {
+    type Output = Indent;
+
+    fn add(self, rhs: usize) -> Indent {
+        Indent { block_indent: self.block_indent, alignment: self.alignment + rhs }
+    }
+}
 
 #[derive(Copy, Clone)]
 pub enum WriteMode {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -14,7 +14,7 @@ use std::iter::Peekable;
 use syntax::codemap::{self, CodeMap, BytePos};
 
 use Indent;
-use utils::{round_up_to_power_of_two, make_indent, wrap_str};
+use utils::{round_up_to_power_of_two, wrap_str};
 use comment::{FindUncommented, rewrite_comment, find_comment_end};
 use config::Config;
 
@@ -155,7 +155,7 @@ pub fn write_list<'b>(items: &[ListItem], formatting: &ListFormatting<'b>) -> Op
     let mut result = String::with_capacity(round_up_to_power_of_two(alloc_width));
 
     let mut line_len = 0;
-    let indent_str = &make_indent(formatting.indent, formatting.config);
+    let indent_str = &formatting.indent.to_string(formatting.config);
     for (i, item) in items.iter().enumerate() {
         let first = i == 0;
         let last = i == items.len() - 1;
@@ -221,7 +221,7 @@ pub fn write_list<'b>(items: &[ListItem], formatting: &ListFormatting<'b>) -> Op
             let formatted_comment = rewrite_comment(comment,
                                                     true,
                                                     formatting.v_width,
-                                                    Indent::new(0, 0),
+                                                    Indent::empty(),
                                                     formatting.config);
 
             result.push(' ');

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -25,6 +25,7 @@ use syntax::ast;
 use syntax::parse::token::{Eof, Comma, Token};
 use syntax::parse::{ParseSess, tts_to_parser};
 
+use Indent;
 use rewrite::RewriteContext;
 use expr::{rewrite_call, rewrite_array};
 use comment::FindUncommented;
@@ -46,7 +47,7 @@ enum MacroStyle {
 pub fn rewrite_macro(mac: &ast::Mac,
                      context: &RewriteContext,
                      width: usize,
-                     offset: usize)
+                     offset: Indent)
                      -> Option<String> {
     let ast::Mac_::MacInvocTT(ref path, ref tt_vec, _) = mac.node;
     let style = macro_style(mac, context);

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use config::Config;
 use visitor::FmtVisitor;
 
 use syntax::codemap::{self, BytePos};
@@ -20,7 +19,8 @@ impl<'a> FmtVisitor<'a> {
         self.format_missing_inner(end, |this, last_snippet, _| this.buffer.push_str(last_snippet))
     }
 
-    pub fn format_missing_with_indent(&mut self, end: BytePos, config: &Config) {
+    pub fn format_missing_with_indent(&mut self, end: BytePos) {
+        let config = self.config;
         self.format_missing_inner(end,
                                   |this, last_snippet, snippet| {
                                       this.buffer.push_str(last_snippet.trim_right());

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use config::Config;
 use utils::make_indent;
 use visitor::FmtVisitor;
 
@@ -20,15 +21,15 @@ impl<'a> FmtVisitor<'a> {
         self.format_missing_inner(end, |this, last_snippet, _| this.buffer.push_str(last_snippet))
     }
 
-    pub fn format_missing_with_indent(&mut self, end: BytePos) {
+    pub fn format_missing_with_indent(&mut self, end: BytePos, config: &Config) {
         self.format_missing_inner(end,
                                   |this, last_snippet, snippet| {
                                       this.buffer.push_str(last_snippet.trim_right());
                                       if last_snippet == snippet {
-                // No new lines in the snippet.
+                                          // No new lines in the snippet.
                                           this.buffer.push_str("\n");
                                       }
-                                      let indent = make_indent(this.block_indent);
+                                      let indent = make_indent(this.block_indent, config);
                                       this.buffer.push_str(&indent);
                                   })
     }

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -9,7 +9,6 @@
 // except according to those terms.
 
 use config::Config;
-use utils::make_indent;
 use visitor::FmtVisitor;
 
 use syntax::codemap::{self, BytePos};
@@ -29,7 +28,7 @@ impl<'a> FmtVisitor<'a> {
                                           // No new lines in the snippet.
                                           this.buffer.push_str("\n");
                                       }
-                                      let indent = make_indent(this.block_indent, config);
+                                      let indent = this.block_indent.to_string(config);
                                       this.buffer.push_str(&indent);
                                   })
     }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -12,6 +12,7 @@
 
 use syntax::codemap::{CodeMap, Span};
 
+use Indent;
 use config::Config;
 
 pub trait Rewrite {
@@ -22,7 +23,7 @@ pub trait Rewrite {
     /// `width` is the maximum number of characters on the last line
     /// (excluding offset). The width of other lines is not limited by
     /// `width`.
-    fn rewrite(&self, context: &RewriteContext, width: usize, offset: usize) -> Option<String>;
+    fn rewrite(&self, context: &RewriteContext, width: usize, offset: Indent) -> Option<String>;
 }
 
 pub struct RewriteContext<'a> {
@@ -30,12 +31,12 @@ pub struct RewriteContext<'a> {
     pub config: &'a Config,
 
     // Indentation due to nesting of blocks.
-    pub block_indent: usize,
+    pub block_indent: Indent,
     // *Extra* indentation due to overflowing to the next line, e.g.,
     // let foo =
     //     bar();
     // The extra 4 spaces when formatting `bar()` is overflow_indent.
-    pub overflow_indent: usize,
+    pub overflow_indent: Indent,
 }
 
 impl<'a> RewriteContext<'a> {
@@ -43,12 +44,12 @@ impl<'a> RewriteContext<'a> {
         RewriteContext {
             codemap: self.codemap,
             config: self.config,
-            block_indent: self.block_indent + self.config.tab_spaces,
+            block_indent: self.block_indent.block_indent(self.config.tab_spaces),
             overflow_indent: self.overflow_indent,
         }
     }
 
-    pub fn overflow_context(&self, overflow: usize) -> RewriteContext<'a> {
+    pub fn overflow_context(&self, overflow: Indent) -> RewriteContext<'a> {
         RewriteContext {
             codemap: self.codemap,
             config: self.config,

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -44,7 +44,7 @@ impl<'a> RewriteContext<'a> {
         RewriteContext {
             codemap: self.codemap,
             config: self.config,
-            block_indent: self.block_indent.block_indent(self.config.tab_spaces),
+            block_indent: self.block_indent.block_indent(self.config),
             overflow_indent: self.overflow_indent,
         }
     }

--- a/src/string.rs
+++ b/src/string.rs
@@ -15,7 +15,7 @@ use regex::Regex;
 
 use Indent;
 use config::Config;
-use utils::{make_indent, round_up_to_power_of_two};
+use utils::round_up_to_power_of_two;
 
 use MIN_STRING;
 
@@ -39,7 +39,7 @@ pub fn rewrite_string<'a>(s: &str, fmt: &StringFormat<'a>) -> String {
 
     let graphemes = UnicodeSegmentation::graphemes(&*stripped_str, false).collect::<Vec<&str>>();
 
-    let indent = make_indent(fmt.offset, fmt.config);
+    let indent = fmt.offset.to_string(fmt.config);
     let indent = &indent;
 
     let mut cur_start = 0;

--- a/src/string.rs
+++ b/src/string.rs
@@ -13,6 +13,8 @@
 use unicode_segmentation::UnicodeSegmentation;
 use regex::Regex;
 
+use Indent;
+use config::Config;
 use utils::{make_indent, round_up_to_power_of_two};
 
 use MIN_STRING;
@@ -23,8 +25,9 @@ pub struct StringFormat<'a> {
     pub line_start: &'a str,
     pub line_end: &'a str,
     pub width: usize,
-    pub offset: usize,
+    pub offset: Indent,
     pub trim_end: bool,
+    pub config: &'a Config,
 }
 
 // TODO: simplify this!
@@ -36,7 +39,7 @@ pub fn rewrite_string<'a>(s: &str, fmt: &StringFormat<'a>) -> String {
 
     let graphemes = UnicodeSegmentation::graphemes(&*stripped_str, false).collect::<Vec<&str>>();
 
-    let indent = make_indent(fmt.offset);
+    let indent = make_indent(fmt.offset, fmt.config);
     let indent = &indent;
 
     let mut cur_start = 0;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,6 @@ use syntax::codemap::{CodeMap, Span, BytePos};
 
 use Indent;
 use comment::FindUncommented;
-use config::Config;
 use rewrite::{Rewrite, RewriteContext};
 
 use SKIP_ANNOTATION;
@@ -35,11 +34,6 @@ pub fn span_after(original: Span, needle: &str, codemap: &CodeMap) -> BytePos {
     let snippet = codemap.span_to_snippet(original).unwrap();
 
     original.lo + BytePos(snippet.find_uncommented(needle).unwrap() as u32 + 1)
-}
-
-#[inline]
-pub fn make_indent(indent: Indent, config: &Config) -> String {
-    indent.to_string(config)
 }
 
 #[inline]

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -58,7 +58,7 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
                 }
             }
             ast::Stmt_::StmtExpr(ref ex, _) | ast::Stmt_::StmtSemi(ref ex, _) => {
-                self.format_missing_with_indent(stmt.span.lo, self.config);
+                self.format_missing_with_indent(stmt.span.lo);
                 let suffix = if let ast::Stmt_::StmtExpr(..) = stmt.node {
                     ""
                 } else {
@@ -78,7 +78,7 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
                 }
             }
             ast::Stmt_::StmtMac(ref _mac, _macro_style) => {
-                self.format_missing_with_indent(stmt.span.lo, self.config);
+                self.format_missing_with_indent(stmt.span.lo);
                 visit::walk_stmt(self, stmt);
             }
         }
@@ -108,7 +108,7 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
 
         match b.expr {
             Some(ref e) => {
-                self.format_missing_with_indent(e.span.lo, self.config);
+                self.format_missing_with_indent(e.span.lo);
                 self.visit_expr(e);
             }
             None => {}
@@ -116,7 +116,7 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
 
         self.block_indent = self.block_indent.block_unindent(self.config);
         // TODO: we should compress any newlines here to just one
-        self.format_missing_with_indent(b.span.hi - brace_compensation, self.config);
+        self.format_missing_with_indent(b.span.hi - brace_compensation);
         self.buffer.push_str("}");
         self.last_pos = b.span.hi;
     }
@@ -165,7 +165,7 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
         };
 
         if let Some(fn_str) = rewrite {
-            self.format_missing_with_indent(s.lo, self.config);
+            self.format_missing_with_indent(s.lo);
             self.buffer.push_str(&fn_str);
         } else {
             self.format_missing(b.span.lo);
@@ -200,26 +200,26 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
                 self.block_indent = self.block_indent.block_unindent(self.config);
             }
             ast::Item_::ItemExternCrate(_) => {
-                self.format_missing_with_indent(item.span.lo, self.config);
+                self.format_missing_with_indent(item.span.lo);
                 let new_str = self.snippet(item.span);
                 self.buffer.push_str(&new_str);
                 self.last_pos = item.span.hi;
             }
             ast::Item_::ItemStruct(ref def, ref generics) => {
-                self.format_missing_with_indent(item.span.lo, self.config);
+                self.format_missing_with_indent(item.span.lo);
                 self.visit_struct(item.ident, item.vis, def, generics, item.span);
             }
             ast::Item_::ItemEnum(ref def, ref generics) => {
-                self.format_missing_with_indent(item.span.lo, self.config);
+                self.format_missing_with_indent(item.span.lo);
                 self.visit_enum(item.ident, item.vis, def, generics, item.span);
                 self.last_pos = item.span.hi;
             }
             ast::Item_::ItemMod(ref module) => {
-                self.format_missing_with_indent(item.span.lo, self.config);
+                self.format_missing_with_indent(item.span.lo);
                 self.format_mod(module, item.span, item.ident);
             }
             ast::Item_::ItemMac(..) => {
-                self.format_missing_with_indent(item.span.lo, self.config);
+                self.format_missing_with_indent(item.span.lo);
                 // TODO: we cannot format these yet, because of a bad span.
                 // See rust lang issue #28424.
                 // visit::walk_item(self, item);
@@ -236,7 +236,7 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
         }
 
         if let ast::TraitItem_::MethodTraitItem(ref sig, None) = ti.node {
-            self.format_missing_with_indent(ti.span.lo, self.config);
+            self.format_missing_with_indent(ti.span.lo);
 
             let indent = self.block_indent;
             let new_fn = self.rewrite_required_fn(indent, ti.ident, sig, ti.span);
@@ -300,7 +300,7 @@ impl<'a> FmtVisitor<'a> {
         }
 
         let first = &attrs[0];
-        self.format_missing_with_indent(first.span.lo, self.config);
+        self.format_missing_with_indent(first.span.lo);
 
         if utils::contains_skip(attrs) {
             true
@@ -366,12 +366,12 @@ impl<'a> FmtVisitor<'a> {
             }
             Some(ref s) => {
                 let s = format!("{}use {};", vis, s);
-                self.format_missing_with_indent(span.lo, self.config);
+                self.format_missing_with_indent(span.lo);
                 self.buffer.push_str(&s);
                 self.last_pos = span.hi;
             }
             None => {
-                self.format_missing_with_indent(span.lo, self.config);
+                self.format_missing_with_indent(span.lo);
                 self.format_missing(span.hi);
             }
         }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -39,12 +39,9 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
                self.codemap.lookup_char_pos(ex.span.hi));
         self.format_missing(ex.span.lo);
 
-        let offset = self.buffer.cur_offset();
-        // FIXME: We put the entire offset into the block_indent, which might not be correct in all
-        // situations.
         let rewrite = ex.rewrite(&self.get_context(),
-                                 self.config.max_width - offset,
-                                 Indent::new(offset, 0));
+                                 self.config.max_width - self.block_indent.width(),
+                                 self.block_indent);
 
         if let Some(new_str) = rewrite {
             self.buffer.push_str(&new_str);

--- a/tests/source/hard-tabs.rs
+++ b/tests/source/hard-tabs.rs
@@ -1,0 +1,69 @@
+// rustfmt-hard_tabs: true
+
+fn main() {
+let x = Bar;
+
+let y = Foo {a: x };
+
+Foo { a: foo() /* comment*/, /* comment*/ b: bar(), ..something };
+
+fn foo(a: i32, a: i32, a: i32, a: i32, a: i32, a: i32, a: i32, a: i32, a: i32, a: i32, a: i32) {}
+
+let str = "AAAAAAAAAAAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaAa";
+
+if let (some_very_large, tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) = 1
++ 2 + 3 {
+}
+
+    if cond() {
+        something();
+    } else  if different_cond() {
+        something_else();
+    } else {
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    }
+    
+unsafe /* very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong comment */ {}
+
+unsafe // So this is a very long comment.
+   // Multi-line, too.
+   // Will it still format correctly?
+{
+}
+
+let z = [xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, yyyyyyyyyyyyyyyyyyyyyyyyyyy, zzzzzzzzzzzzzzzzzz, q];
+
+fn generic<T>(arg: T) -> &SomeType
+    where T: Fn(// First arg
+        A,
+        // Second argument
+        B, C, D, /* pre comment */ E /* last comment */) -> &SomeType {
+    arg(a, b, c, d, e)    
+}
+
+    loong_func().quux(move || {
+        if true {
+            1
+        } else {
+            2
+        }
+    });
+
+    fffffffffffffffffffffffffffffffffff(a,
+                                        {
+                                            SCRIPT_TASK_ROOT
+                                            .with(|root| {
+                                                *root.borrow_mut()  =   Some(&script_task);
+                                            });
+                                        });
+    a.b
+     .c
+     .d();
+    
+    x().y(|| {
+        match cond() {
+            true => (),
+            false => (),
+        }
+    });
+}

--- a/tests/target/hard-tabs.rs
+++ b/tests/target/hard-tabs.rs
@@ -1,0 +1,95 @@
+// rustfmt-hard_tabs: true
+
+fn main() {
+	let x = Bar;
+
+	let y = Foo { a: x };
+
+	Foo {
+		a: foo(), // comment
+		// comment
+		b: bar(),
+		..something
+	};
+
+	fn foo(a: i32,
+	       a: i32,
+	       a: i32,
+	       a: i32,
+	       a: i32,
+	       a: i32,
+	       a: i32,
+	       a: i32,
+	       a: i32,
+	       a: i32,
+	       a: i32) {
+	}
+
+	let str = "AAAAAAAAAAAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaAAAAAAAAAAAAAAAAAAAAA\
+	           AAAAAAAAAAAAaAa";
+
+	if let (some_very_large, tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuple) =
+	       1 + 2 + 3 {
+	}
+
+	if cond() {
+		something();
+	} else if different_cond() {
+		something_else();
+	} else {
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+	}
+
+	unsafe /* very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong
+	        * comment */ {
+	}
+
+	unsafe /* So this is a very long comment.
+	        * Multi-line, too.
+	        * Will it still format correctly? */ {
+	}
+
+	let z = [xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
+	         yyyyyyyyyyyyyyyyyyyyyyyyyyy,
+	         zzzzzzzzzzzzzzzzzz,
+	         q];
+
+	fn generic<T>(arg: T) -> &SomeType
+		where T: Fn(// First arg
+		            A,
+		            // Second argument
+		            B,
+		            C,
+		            D,
+		            // pre comment
+		            E /* last comment */) -> &SomeType
+	{
+		arg(a, b, c, d, e)
+	}
+
+	loong_func().quux(move || {
+		if true {
+			1
+		} else {
+			2
+		}
+	});
+
+	fffffffffffffffffffffffffffffffffff(a,
+	                                    {
+		                                    SCRIPT_TASK_ROOT.with(|root| {
+			                                    *root.borrow_mut() = Some(&script_task);
+		                                    });
+	                                    });
+	a.b
+	 .c
+	 .d();
+
+	x().y(|| {
+		match cond() {
+			true => (),
+			false => (),
+		}
+	});
+}


### PR DESCRIPTION
This is a draft, as perhaps not all implementation choices I made are ideal. I also wasn't sure what to do with tests.

The general idea of this change is to switch from using a plain `usize` to track indentation to a special `Indent` type which tracks block indentation and alignment (for visual alignment) separately. Adding the hard tab mode on top of that is then trivial. This increased type safety should prevent bugs where width is passed instead of offset and vice versa (e.g. see a possible bug in `src/items.rs:61-62`).

I've tested the patch and it seems to work fine in most cases. It doesn't interact well with visual indentation for function arguments + closures, but I don't think there's expectation that every possible indentation configuration option should result in a sensible style.