### PR TITLE
Prevent generation of bogus comment in some function calls

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -40,7 +40,8 @@ impl Rewrite for ast::Expr {
                 }
             }
             ast::Expr_::ExprCall(ref callee, ref args) => {
-                rewrite_call(context, &**callee, args, self.span, width, offset)
+                let inner_span = mk_sp(callee.span.hi, self.span.hi);
+                rewrite_call(context, &**callee, args, inner_span, width, offset)
             }
             ast::Expr_::ExprParen(ref subexpr) => {
                 rewrite_paren(context, subexpr, width, offset)

--- a/tests/source/closure.rs
+++ b/tests/source/closure.rs
@@ -44,3 +44,9 @@ fn main() {
     |arg1, arg2, _, _, arg3, arg4| { let temp = arg4 + arg3;
                                      arg2 * arg1 - temp }
 }
+
+fn issue311() {
+    let func = |x| println!("{}", x);
+
+    (func)(0.0);
+}

--- a/tests/target/closure.rs
+++ b/tests/target/closure.rs
@@ -70,3 +70,9 @@ fn main() {
         arg2 * arg1 - temp
     }
 }
+
+fn issue311() {
+    let func = |x| println!("{}", x);
+
+    (func)(0.0);
+}


### PR DESCRIPTION
This would happen when the callee contained parentheses.

Fixes https://github.com/nrc/rustfmt/issues/311.