### PR TITLE
find_commented and fix https://github.com/nrc/rustfmt/issues/284

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -14,6 +14,7 @@ use std::iter;
 
 use string::{StringFormat, rewrite_string};
 use utils::make_indent;
+use regex::Regex;
 
 pub fn rewrite_comment(orig: &str, block_style: bool, width: usize, offset: usize) -> String {
     let s = orig.trim();
@@ -97,11 +98,12 @@ fn left_trim_comment_line(line: &str) -> &str {
     }
 }
 
-pub trait FindUncommented {
+pub trait CommentFinder {
     fn find_uncommented(&self, pat: &str) -> Option<usize>;
+    fn find_commented(&self) -> Option<&str>;
 }
 
-impl FindUncommented for str {
+impl CommentFinder for str {
     fn find_uncommented(&self, pat: &str) -> Option<usize> {
         let mut needle_iter = pat.chars();
         for (kind, (i, b)) in CharClasses::new(self.char_indices()) {
@@ -123,6 +125,16 @@ impl FindUncommented for str {
             Some(_) => None,
             None => Some(self.len() - pat.len()),
         }
+    }
+
+    // Returns the first comment in a code string
+    // It'll not work with string literals
+    fn find_commented(&self) -> Option<&str> {
+        let re = Regex::new(r"((?s)/\*.*?\*/)|((?-s)//.*)").unwrap();
+        if let Some((lo, hi)) = re.find(self) {
+            return Some(&self[lo..hi]);
+        }
+        None
     }
 }
 
@@ -286,7 +298,7 @@ impl<T> Iterator for CharClasses<T> where T: Iterator, T::Item: RichChar {
 
 #[cfg(test)]
 mod test {
-    use super::{CharClasses, CodeCharKind, contains_comment, rewrite_comment, FindUncommented};
+    use super::{CharClasses, CodeCharKind, contains_comment, rewrite_comment, CommentFinder};
 
     #[test]
     fn format_comments() {
@@ -359,5 +371,17 @@ mod test {
         check("/**/abc/* */", "abc", Some(4));
         check("\"/* abc */\"", "abc", Some(4));
         check("\"/* abc", "abc", Some(4));
+    }
+
+    #[test]
+    fn test_find_commented() {
+        assert_eq!("asdf".find_commented(), None);
+        assert_eq!("asdf /* comment /* /* */".find_commented(), Some("/* comment /* /* */"));
+        assert_eq!("asdf /* comment \n * line 2 */".find_commented(),
+            Some("/* comment \n * line 2 */"));
+        assert_eq!("asdf /* comment \n\n\n //asdf */".find_commented(),
+            Some("/* comment \n\n\n //asdf */"));
+        assert_eq!("asdf // comment\n".find_commented(), Some("// comment"));
+        assert_eq!("asdf // comment\n\n\n".find_commented(), Some("// comment"));
     }
 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -19,7 +19,7 @@ use utils::{span_after, make_indent, extra_offset, first_line_width, last_line_w
             binary_search};
 use visitor::FmtVisitor;
 use config::MultilineStyle;
-use comment::{FindUncommented, rewrite_comment, contains_comment};
+use comment::{CommentFinder, rewrite_comment, contains_comment};
 use types::rewrite_path;
 use items::{span_lo_for_arg, span_hi_for_arg};
 use chains::rewrite_chain;
@@ -117,7 +117,7 @@ impl Rewrite for ast::Expr {
                               offset)
             }
             ast::Expr_::ExprMatch(ref cond, ref arms, _) => {
-                rewrite_match(context, cond, arms, width, offset)
+                rewrite_match(context, cond, arms, self.span, width, offset)
             }
             ast::Expr_::ExprPath(ref qself, ref path) => {
                 rewrite_path(context, qself.as_ref(), path, width, offset)
@@ -618,6 +618,7 @@ fn is_simple_block(block: &ast::Block, codemap: &CodeMap) -> bool {
 fn rewrite_match(context: &RewriteContext,
                  cond: &ast::Expr,
                  arms: &[ast::Arm],
+                 span: Span,
                  width: usize,
                  offset: usize)
                  -> Option<String> {
@@ -677,10 +678,16 @@ fn rewrite_match(context: &RewriteContext,
             result.push_str(&snippet);
         }
     }
+    // Last arm and the end of the match expression.
+    let last_str = context.snippet(mk_sp(arm_end_pos(arms.last().unwrap()), span.hi));
+    let last_com = last_str.find_commented();
 
-    // We'll miss any comments etc. between the last arm and the end of the
-    // match expression, but meh.
-
+    if let Some(last_com) = last_com {
+        let fmt_com = rewrite_comment(last_com, true, width, arm_indent);
+        result.push('\n');
+        result.push_str(&arm_indent_str);
+        result.push_str(&fmt_com);
+    }
     result.push('\n');
     result.push_str(&make_indent(context.block_indent + context.overflow_indent));
     result.push('}');

--- a/src/items.rs
+++ b/src/items.rs
@@ -15,7 +15,7 @@ use utils::{format_mutability, format_visibility, make_indent, contains_skip, sp
             end_typaram, wrap_str};
 use lists::{write_list, itemize_list, ListItem, ListFormatting, SeparatorTactic, ListTactic};
 use expr::rewrite_assign_rhs;
-use comment::FindUncommented;
+use comment::CommentFinder;
 use visitor::FmtVisitor;
 use rewrite::{Rewrite, RewriteContext};
 use config::{Config, BlockIndentStyle, Density};

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -14,7 +14,7 @@ use std::iter::Peekable;
 use syntax::codemap::{self, CodeMap, BytePos};
 
 use utils::{round_up_to_power_of_two, make_indent, wrap_str};
-use comment::{FindUncommented, rewrite_comment, find_comment_end};
+use comment::{CommentFinder, rewrite_comment, find_comment_end};
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub enum ListTactic {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,7 +13,7 @@ use std::cmp::Ordering;
 use syntax::ast::{self, Visibility, Attribute, MetaItem, MetaItem_};
 use syntax::codemap::{CodeMap, Span, BytePos};
 
-use comment::FindUncommented;
+use comment::CommentFinder;
 use rewrite::{Rewrite, RewriteContext};
 
 use SKIP_ANNOTATION;

--- a/tests/source/match-1.rs
+++ b/tests/source/match-1.rs
@@ -1,0 +1,16 @@
+fn main() {
+    match x {
+        1 => (),
+        2 => return, // A comment.
+    }
+    
+    match y {
+        1 => (),
+        2 => return, // Another comment that needs rewrite because it's toooooooooooooooooooooo looooooooooooooooooooong.
+        
+        
+        
+        
+        
+    }
+}

--- a/tests/target/match-1.rs
+++ b/tests/target/match-1.rs
@@ -1,0 +1,14 @@
+fn main() {
+    match x {
+        1 => (),
+        2 => return,
+        /* A comment. */
+    }
+
+    match y {
+        1 => (),
+        2 => return,
+        /* Another comment that needs rewrite because it's toooooooooooooooooooooo
+         * looooooooooooooooooooong. */
+    }
+}


### PR DESCRIPTION
Added the find_commented method and ComentFinder trait. The find_commneted should be useful in other places where we're ignoring comments.