### PR TITLE
Fixed https://github.com/nrc/rustfmt/issues/291

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -18,6 +18,7 @@ extern crate toml;
 
 use rustfmt::{WriteMode, run};
 use rustfmt::config::Config;
+use rustfmt::config::ConfigHelpVariantTypes;
 
 use std::env;
 use std::fs::{File, PathExt};
@@ -85,6 +86,16 @@ fn print_usage<S: Into<String>>(reason: S) {
     println!("{}\n\r usage: rustfmt [-h Help] [--write-mode=[replace|overwrite|display|diff]] \
               <file_name>",
              reason.into());
+
+    for option in Config::get_docs() {
+        let variants = option.variant_names();
+        let variant_names: String = match *variants {
+            ConfigHelpVariantTypes::UsizeConfig => "<unsigned integer>".into(),
+            ConfigHelpVariantTypes::BoolConfig => "<boolean>".into(),
+            ConfigHelpVariantTypes::EnumConfig(ref variants) => variants.join(", "),
+        };
+        println!("{}, {}, Possible values: {}", option.option_name(), option.doc_string(), variant_names);
+    }
 }
 
 fn determine_params<I>(args: I) -> Option<(Vec<String>, WriteMode)>

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -17,8 +17,7 @@ extern crate rustfmt;
 extern crate toml;
 
 use rustfmt::{WriteMode, run};
-use rustfmt::config::Config;
-use rustfmt::config::ConfigHelpVariantTypes;
+use rustfmt::config::{Config, ConfigHelpVariantTypes};
 
 use std::env;
 use std::fs::{File, PathExt};

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -17,7 +17,7 @@ extern crate rustfmt;
 extern crate toml;
 
 use rustfmt::{WriteMode, run};
-use rustfmt::config::{Config, ConfigHelpVariantTypes};
+use rustfmt::config::Config;
 
 use std::env;
 use std::fs::{File, PathExt};
@@ -87,13 +87,7 @@ fn print_usage<S: Into<String>>(reason: S) {
              reason.into());
 
     for option in Config::get_docs() {
-        let variants = option.variant_names();
-        let variant_names: String = match *variants {
-            ConfigHelpVariantTypes::UsizeConfig => "<unsigned integer>".into(),
-            ConfigHelpVariantTypes::BoolConfig => "<boolean>".into(),
-            ConfigHelpVariantTypes::EnumConfig(ref variants) => variants.join(", "),
-        };
-        println!("{}, {}, Possible values: {}", option.option_name(), option.doc_string(), variant_names);
+        println!("{}, {}, Possible values: {}", option.option_name(), option.doc_string(), option.variant_names());
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,7 +199,7 @@ create_config! {
     reorder_imports: bool, "Reorder import statements alphabetically", // Alphabetically, case sensitive.
     single_line_if_else: bool, "Put else on same line as closing brace for if statements",
     format_strings: bool, "Format string literals, or leave as is",
-    chains_overflow_last: bool, "chains overflow last",
+    chains_overflow_last: bool, "Allow last call in method chain to break the line",
     take_source_hints: bool, "Retain some formatting characteristics from the source code",
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,34 +82,28 @@ macro_rules! create_config {
             $(pub $i: Option<$ty>),+
         }
 
-        // This trait and the following impl blocks are there only so that we
-        // can use UCFS inside the get_docs() function on builtin types for configs.
-        trait IsConfigType {
-            fn get_variant_names() -> Vec<&'static str>;
+        // This trait and the following impl blocks are there so that we an use
+        // UCFS inside the get_docs() function on types for configs.
+        pub trait ConfigType {
+            fn get_variant_names() -> String;
         }
 
-        impl IsConfigType for bool {
-            fn get_variant_names() -> Vec<&'static str> {
-                unreachable!()
+        impl ConfigType for bool {
+            fn get_variant_names() -> String {
+                String::from("<boolean>")
             }
         }
 
-        impl IsConfigType for usize {
-            fn get_variant_names() -> Vec<&'static str> {
-                unreachable!()
+        impl ConfigType for usize {
+            fn get_variant_names() -> String {
+                String::from("<unsigned integer>")
             }
         }
 
         pub struct ConfigHelpItem {
             option_name: &'static str,
             doc_string : &'static str,
-            variant_names: ConfigHelpVariantTypes,
-        }
-
-        pub enum ConfigHelpVariantTypes {
-            UsizeConfig,
-            BoolConfig,
-            EnumConfig(Vec<&'static str>),
+            variant_names: String,
         }
 
         impl ConfigHelpItem {
@@ -121,7 +115,7 @@ macro_rules! create_config {
                 self.doc_string
             }
 
-            pub fn variant_names(&self) -> &ConfigHelpVariantTypes {
+            pub fn variant_names(&self) -> &String {
                 &self.variant_names
             }
         }
@@ -165,15 +159,10 @@ macro_rules! create_config {
             pub fn get_docs() -> Vec<ConfigHelpItem> {
                 let mut options: Vec<ConfigHelpItem> = Vec::new();
                 $(
-                    let config_variant_type = match stringify!($ty) {
-                        "bool" => ConfigHelpVariantTypes::BoolConfig,
-                        "usize" => ConfigHelpVariantTypes::UsizeConfig,
-                        _ => ConfigHelpVariantTypes::EnumConfig(<$ty>::get_variant_names()),
-                    };
                     options.push(ConfigHelpItem {
                         option_name: stringify!($i),
                         doc_string: stringify!($dstring),
-                        variant_names: config_variant_type,
+                        variant_names: <$ty>::get_variant_names(),
                     });
                 )+
                 options

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -161,6 +161,17 @@ macro_rules! impl_enum_decodable {
                 }
             }
         }
+
+        impl $e {
+            pub fn get_variant_names() -> Vec<&'static str> {
+                let mut variants = Vec::new();
+                $(
+                    variants.push(stringify!($x));
+                )*
+
+                variants
+            }
+        }
     };
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -162,14 +162,14 @@ macro_rules! impl_enum_decodable {
             }
         }
 
-        impl $e {
-            pub fn get_variant_names() -> Vec<&'static str> {
+        impl ::config::ConfigType for $e {
+            fn get_variant_names() -> String {
                 let mut variants = Vec::new();
                 $(
                     variants.push(stringify!($x));
                 )*
 
-                variants
+                variants.join(", ")
             }
         }
     };


### PR DESCRIPTION
Added to the create_config! macro to automatically create usage output when config options are added, as well as outputting all possible values for them.