### PR TITLE
Place the closing brace of an inline mod on a new line

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -326,11 +326,13 @@ impl<'a> FmtVisitor<'a> {
         // TODO: Should rewrite properly `mod X;`
 
         if is_internal {
-            debug!("FmtVisitor::format_mod: internal mod");
             self.block_indent = self.block_indent.block_indent(self.config);
             visit::walk_mod(self, m);
-            debug!("... last_pos after: {:?}", self.last_pos);
             self.block_indent = self.block_indent.block_unindent(self.config);
+
+            self.format_missing_with_indent(m.inner.hi - BytePos(1));
+            self.buffer.push_str("}");
+            self.last_pos = m.inner.hi;
         }
     }
 

--- a/tests/source/mod-1.rs
+++ b/tests/source/mod-1.rs
@@ -1,0 +1,17 @@
+// Deeply indented modules.
+
+  mod foo { mod bar { mod baz {} } }
+
+mod foo {
+    mod bar {
+    mod baz {
+    fn foo() { bar() }
+    }
+    }
+
+    mod qux {
+
+    }
+}
+
+mod boxed { pub use std::boxed::{Box, HEAP}; }

--- a/tests/target/mod-1.rs
+++ b/tests/target/mod-1.rs
@@ -3,6 +3,13 @@
 mod foo {
     mod bar {
         mod baz {
+        }
+    }
+}
+
+mod foo {
+    mod bar {
+        mod baz {
             fn foo() {
                 bar()
             }
@@ -12,4 +19,8 @@ mod foo {
     mod qux {
 
     }
+}
+
+mod boxed {
+    pub use std::boxed::{Box, HEAP};
 }


### PR DESCRIPTION
Fixes https://github.com/nrc/rustfmt/issues/319.

Blocked by https://github.com/rust-lang/rust/pull/28534.