### PR TITLE
match arms collapse for issue #339

### DIFF
--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -140,6 +140,64 @@ fn matches() {
     }
 }
 
+fn issue339() {
+    match a {
+        b => {}
+        c => { }
+        d => {
+        }
+        e => {
+
+
+
+        }
+        // collapsing here is safe
+        ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff => {
+        }
+        // collapsing here exceeds line length
+        ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffg => {
+        }
+        h => { // comment above block
+        }
+        i => {
+        } // comment below block
+        j => {
+            // comment inside block
+        }
+        j2 => {
+            // comments inside...
+        } // ... and after
+        // TODO uncomment when vertical whitespace is handled better
+        // k => {
+        //
+        //     // comment with WS above
+        // }
+        // l => {
+        //     // comment with ws below
+        //     
+        // }
+        m => {
+        } n => { } o =>
+        {
+
+        }
+        p => { // Dont collapse me
+        } q => { } r =>
+        {
+
+        }
+        s => 0, // s comment
+        // t comment
+        t => 1,
+        u => 2,
+        // TODO uncomment when block-support exists
+        // v => {
+        // } /* funky block
+        //    * comment */
+        // final comment
+    }
+}
+
 fn arrays() {
     let x = [0,
          1,

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -169,13 +169,59 @@ fn issue184(source: &str) {
 
 fn matches() {
     match 1 {
-        1 => 1,
-        // foo
+        1 => 1, // foo
         2 => 2,
         // bar
         3 => 3,
-        _ => 0,
-        // baz
+        _ => 0, // baz
+    }
+}
+
+fn issue339() {
+    match a {
+        b => {}
+        c => {}
+        d => {}
+        e => {}
+        // collapsing here is safe
+        ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff => {}
+        // collapsing here exceeds line length
+        ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffg => {
+        }
+        h => { // comment above block
+        }
+        i => {} // comment below block
+        j => {
+            // comment inside block
+        }
+        j2 => {
+            // comments inside...
+        } // ... and after
+        // TODO uncomment when vertical whitespace is handled better
+        // k => {
+        //
+        //     // comment with WS above
+        // }
+        // l => {
+        //     // comment with ws below
+        //
+        // }
+        m => {}
+        n => {}
+        o => {}
+        p => { // Dont collapse me
+        }
+        q => {}
+        r => {}
+        s => 0, // s comment
+        // t comment
+        t => 1,
+        u => 2,
+        // TODO uncomment when block-support exists
+        // v => {
+        // } /* funky block
+        //    * comment */
+        // final comment
     }
 }
 

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -38,8 +38,7 @@ fn foo() {
         _ => {}
         ast::PathParameters::AngleBracketedParameters(ref data) if data.lifetimes.len() > 0 ||
                                                                    data.types.len() > 0 ||
-                                                                   data.bindings.len() > 0 => {
-        }
+                                                                   data.bindings.len() > 0 => {}
     }
 
     let whatever = match something {


### PR DESCRIPTION
Few things
 - we had a test case that violated this anyway, changed that case assuming this is the desired behaviour
 - functionalised nop-block-collapsing because `if`,`fn`, `struct`, `loop` etc. might want the same treatment
 - this code only executes for match arms, the above constructs could use same idea, but currently dont, implementing it for all (i.e. in Block.rewrite) causes many test-cases to fail.

Outstanding:
 - vertical whitespace issues.  Awaiting what to do about vertical whitespace,
cant format:
```
a => {

    //some comment


}
```
to
```
a => {
    //some comment
}
```
as expected, without some policy on vertical whitespace, which will be global, not just match arms