### PR TITLE
Use the maximum available width in struct formatting

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1152,9 +1152,10 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
                                  match *item {
                                      StructLitField::Regular(ref field) => field.span.lo,
                                      StructLitField::Base(ref expr) => {
-                                         let last_field_hi = fields.last()
-                                                                   .map_or(span.lo,
-                                                                           |field| field.span.hi);
+                                         let last_field_hi = fields.last().map_or(span.lo,
+                                                                                  |field| {
+                                                                                      field.span.hi
+                                                                                  });
                                          let snippet = context.snippet(mk_sp(last_field_hi,
                                                                              expr.span.lo));
                                          let pos = snippet.find_uncommented("..").unwrap();

--- a/src/items.rs
+++ b/src/items.rs
@@ -788,8 +788,8 @@ impl<'a> FmtVisitor<'a> {
             ends_with_newline: true,
             config: self.config,
         };
-        let list_str = write_list(&items.collect::<Vec<_>>(), &fmt).unwrap();
 
+        let list_str = try_opt!(write_list(&items.collect::<Vec<_>>(), &fmt));
         result.push_str(&list_str);
 
         if break_line {
@@ -819,11 +819,12 @@ impl<'a> FmtVisitor<'a> {
                                         struct_def,
                                         Some(generics),
                                         span,
-                                        indent)
-                         .unwrap();
+                                        indent);
 
-        self.buffer.push_str(&result);
-        self.last_pos = span.hi;
+        if let Some(rewrite) = result {
+            self.buffer.push_str(&rewrite);
+            self.last_pos = span.hi;
+        }
     }
 
     fn format_header(&self, item_name: &str, ident: ast::Ident, vis: ast::Visibility) -> String {

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -214,9 +214,11 @@ pub fn write_list<'b>(items: &[ListItem], formatting: &ListFormatting<'b>) -> Op
             }
         }
 
-        let max_width = formatting.indent.width() + formatting.v_width;
-        let item_str = wrap_str(&item.item[..], max_width, formatting.v_width, formatting.indent);
-        result.push_str(&&try_opt!(item_str));
+        let item_str = try_opt!(wrap_str(&item.item[..],
+                                         formatting.config.max_width,
+                                         formatting.v_width,
+                                         formatting.indent));
+        result.push_str(&item_str);
 
         // Post-comments
         if tactic != ListTactic::Vertical && item.post_comment.is_some() {

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -102,3 +102,6 @@ pub struct State<F: FnMut() -> time::Timespec> { now: F }
 pub struct State<F: FnMut() -> ()> { now: F }
 
 pub struct State<F: FnMut()> { now: F }
+
+struct Palette { /// A map of indizes in the palette to a count of pixels in approximately that color
+                    foo: i32}

--- a/tests/target/structs.rs
+++ b/tests/target/structs.rs
@@ -95,3 +95,8 @@ pub struct State<F: FnMut() -> ()> {
 pub struct State<F: FnMut()> {
     now: F,
 }
+
+struct Palette {
+    /// A map of indizes in the palette to a count of pixels in approximately that color
+    foo: i32,
+}


### PR DESCRIPTION
Previously, we'd use an approximation for the maximum width since the configuration wasn't available in `write_list`.

Fixes https://github.com/nrc/rustfmt/issues/360.