### PR TITLE
Fix https://github.com/nrc/rustfmt/issues/389

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -39,6 +39,7 @@ pub fn rewrite_string<'a>(s: &str, fmt: &StringFormat<'a>) -> Option<String> {
 
     let graphemes = UnicodeSegmentation::graphemes(&*stripped_str, false).collect::<Vec<&str>>();
     let indent = fmt.offset.to_string(fmt.config);
+    let punctuation = ":,;.";
 
     let mut cur_start = 0;
     let mut result = String::with_capacity(round_up_to_power_of_two(s.len()));
@@ -62,11 +63,22 @@ pub fn rewrite_string<'a>(s: &str, fmt: &StringFormat<'a>) -> Option<String> {
         while !graphemes[cur_end - 1].trim().is_empty() {
             cur_end -= 1;
             if cur_end - cur_start < MIN_STRING {
-                // We can't break at whitespace, fall back to splitting
-                // anywhere that doesn't break an escape sequence.
                 cur_end = cur_start + max_chars;
-                while graphemes[cur_end - 1] == "\\" {
-                    cur_end -= 1;
+                // Look for punctuation to break on.
+                while (!punctuation.contains(graphemes[cur_end - 1])) && cur_end > 1 {
+                    if cur_end > 1 {
+                        cur_end -= 1;
+                    }
+                }
+                // We can't break at whitespace or punctuation, fall back to splitting
+                // anywhere that doesn't break an escape sequence.
+                if cur_end < cur_start + MIN_STRING {
+                    cur_end = cur_start + max_chars;
+                    while graphemes[cur_end - 1] == "\\" {
+                        if cur_end > 1 {
+                            cur_end -= 1;
+                        }
+                    }
                 }
                 break;
             }

--- a/src/string.rs
+++ b/src/string.rs
@@ -66,18 +66,14 @@ pub fn rewrite_string<'a>(s: &str, fmt: &StringFormat<'a>) -> Option<String> {
                 cur_end = cur_start + max_chars;
                 // Look for punctuation to break on.
                 while (!punctuation.contains(graphemes[cur_end - 1])) && cur_end > 1 {
-                    if cur_end > 1 {
-                        cur_end -= 1;
-                    }
+                    cur_end -= 1;
                 }
                 // We can't break at whitespace or punctuation, fall back to splitting
                 // anywhere that doesn't break an escape sequence.
                 if cur_end < cur_start + MIN_STRING {
                     cur_end = cur_start + max_chars;
-                    while graphemes[cur_end - 1] == "\\" {
-                        if cur_end > 1 {
-                            cur_end -= 1;
-                        }
+                    while graphemes[cur_end - 1] == "\\" && cur_end > 1 {
+                        cur_end -= 1;
                     }
                 }
                 break;

--- a/tests/source/string_punctuation.rs
+++ b/tests/source/string_punctuation.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("ThisIsAReallyLongStringWithNoSpaces.It_should_prefer_to_break_onpunctuation:Likethisssssssssssss");
+    format!("{}__{}__{}ItShouldOnlyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyNoticeSemicolonsPeriodsColonsAndCommasAndResortToMid-CharBreaksAfterPunctuation{}{}",x,y,z,a,b);
+    println!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaalhijalfhiigjapdighjapdigjapdighdapighapdighpaidhg;adopgihadoguaadbadgad,qeoihapethae8t0aet8haetadbjtaeg;ooeouthaoeutgadlgajduabgoiuadogabudogubaodugbadgadgadga;adoughaoeugbaouea");
+}

--- a/tests/target/string_punctuation.rs
+++ b/tests/target/string_punctuation.rs
@@ -1,0 +1,14 @@
+fn main() {
+    println!("ThisIsAReallyLongStringWithNoSpaces.It_should_prefer_to_break_onpunctuation:\
+              Likethisssssssssssss");
+    format!("{}__{}__{}ItShouldOnlyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyNoticeSemicolonsPeriodsColo\
+             nsAndCommasAndResortToMid-CharBreaksAfterPunctuation{}{}",
+            x,
+            y,
+            z,
+            a,
+            b);
+    println!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaalhijalfhiigjapdighjapdigjapdighdapighapdighpaidhg;\
+              adopgihadoguaadbadgad,qeoihapethae8t0aet8haetadbjtaeg;\
+              ooeouthaoeutgadlgajduabgoiuadogabudogubaodugbadgadgadga;adoughaoeugbaouea");
+}


### PR DESCRIPTION
rewrite_string now prefers to look for punctuation to split on, and then goes to the nearest non-escape character as a last resort.