### PR TITLE
Format casts, indices and repeated elements

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -111,13 +111,6 @@ impl Rewrite for ast::Expr {
                                 offset,
                                 true)
             }
-            ast::Expr_::ExprRange(ref left, ref right) => {
-                rewrite_range(context,
-                              left.as_ref().map(|e| &**e),
-                              right.as_ref().map(|e| &**e),
-                              width,
-                              offset)
-            }
             ast::Expr_::ExprMatch(ref cond, ref arms, _) => {
                 rewrite_match(context, cond, arms, width, offset, self.span)
             }
@@ -178,13 +171,32 @@ impl Rewrite for ast::Expr {
                 rewrite_expr_addrof(context, mutability, expr, width, offset)
             }
             ast::Expr_::ExprCast(ref expr, ref ty) => {
-                rewrite_cast(expr, ty, context, width, offset)
+                rewrite_pair(&**expr, &**ty, "", " as ", "", context, width, offset)
             }
             ast::Expr_::ExprIndex(ref expr, ref index) => {
-                rewrite_index(expr, index, context, width, offset)
+                rewrite_pair(&**expr, &**index, "", "[", "]", context, width, offset)
             }
             ast::Expr_::ExprRepeat(ref expr, ref repeats) => {
-                rewrite_repeats(expr, repeats, context, width, offset)
+                rewrite_pair(&**expr, &**repeats, "[", "; ", "]", context, width, offset)
+            }
+            ast::Expr_::ExprRange(Some(ref lhs), Some(ref rhs)) => {
+                rewrite_pair(&**lhs, &**rhs, "", "..", "", context, width, offset)
+            }
+            ast::Expr_::ExprRange(None, Some(ref rhs)) => {
+                rewrite_unary_prefix(context, "..", &**rhs, width, offset)
+            }
+            ast::Expr_::ExprRange(Some(ref lhs), None) => {
+                Some(format!("{}..",
+                             try_opt!(lhs.rewrite(context,
+                                                  try_opt!(width.checked_sub(2)),
+                                                  offset))))
+            }
+            ast::Expr_::ExprRange(None, None) => {
+                if width >= 2 {
+                    Some("..".into())
+                } else {
+                    None
+                }
             }
             // We do not format these expressions yet, but they should still
             // satisfy our width restrictions.
@@ -199,99 +211,42 @@ impl Rewrite for ast::Expr {
     }
 }
 
-fn rewrite_repeats(expr: &ast::Expr,
-                   index: &ast::Expr,
-                   context: &RewriteContext,
-                   width: usize,
-                   offset: Indent)
-                   -> Option<String> {
-    let max_width = try_opt!(width.checked_sub("[; ]".len()));
+fn rewrite_pair<LHS, RHS>(lhs: &LHS,
+                          rhs: &RHS,
+                          prefix: &str,
+                          infix: &str,
+                          suffix: &str,
+                          context: &RewriteContext,
+                          width: usize,
+                          offset: Indent)
+                          -> Option<String>
+    where LHS: Rewrite,
+          RHS: Rewrite
+{
+    let max_width = try_opt!(width.checked_sub(prefix.len() + infix.len() + suffix.len()));
 
     binary_search(1,
                   max_width,
-                  |expr_budget| {
-                      let expr_str = match expr.rewrite(context, expr_budget, offset + "[".len()) {
+                  |lhs_budget| {
+                      let lhs_offset = offset + prefix.len();
+                      let lhs_str = match lhs.rewrite(context, lhs_budget, lhs_offset) {
                           Some(result) => result,
                           None => return Err(Ordering::Greater),
                       };
 
-                      let last_line_width = last_line_width(&expr_str);
-                      let index_budget = match max_width.checked_sub(last_line_width) {
+                      let last_line_width = last_line_width(&lhs_str);
+                      let rhs_budget = match max_width.checked_sub(last_line_width) {
                           Some(b) => b,
                           None => return Err(Ordering::Less),
                       };
-                      let index_indent = offset + last_line_width + "[; ".len();
+                      let rhs_indent = offset + last_line_width + prefix.len() + infix.len();
 
-                      let index_str = match index.rewrite(context, index_budget, index_indent) {
+                      let rhs_str = match rhs.rewrite(context, rhs_budget, rhs_indent) {
                           Some(result) => result,
                           None => return Err(Ordering::Less),
                       };
 
-                      Ok(format!("[{}; {}]", expr_str, index_str))
-                  })
-}
-
-fn rewrite_index(expr: &ast::Expr,
-                 index: &ast::Expr,
-                 context: &RewriteContext,
-                 width: usize,
-                 offset: Indent)
-                 -> Option<String> {
-    let max_width = try_opt!(width.checked_sub("[]".len()));
-
-    binary_search(1,
-                  max_width,
-                  |expr_budget| {
-                      let expr_str = match expr.rewrite(context, expr_budget, offset) {
-                          Some(result) => result,
-                          None => return Err(Ordering::Greater),
-                      };
-
-                      let last_line_width = last_line_width(&expr_str);
-                      let index_budget = match max_width.checked_sub(last_line_width) {
-                          Some(b) => b,
-                          None => return Err(Ordering::Less),
-                      };
-                      let index_indent = offset + last_line_width + "[".len();
-
-                      let index_str = match index.rewrite(context, index_budget, index_indent) {
-                          Some(result) => result,
-                          None => return Err(Ordering::Less),
-                      };
-
-                      Ok(format!("{}[{}]", expr_str, index_str))
-                  })
-}
-
-fn rewrite_cast(expr: &ast::Expr,
-                ty: &ast::Ty,
-                context: &RewriteContext,
-                width: usize,
-                offset: Indent)
-                -> Option<String> {
-    let max_width = try_opt!(width.checked_sub(" as ".len()));
-
-    binary_search(1,
-                  max_width,
-                  |expr_budget| {
-                      let expr_str = match expr.rewrite(context, expr_budget, offset) {
-                          Some(result) => result,
-                          None => return Err(Ordering::Greater),
-                      };
-
-                      let last_line_width = last_line_width(&expr_str);
-                      let ty_budget = match max_width.checked_sub(last_line_width) {
-                          Some(b) => b,
-                          None => return Err(Ordering::Less),
-                      };
-                      let ty_indent = offset + last_line_width + " as ".len();
-
-                      let ty_str = match ty.rewrite(context, ty_budget, ty_indent) {
-                          Some(result) => result,
-                          None => return Err(Ordering::Less),
-                      };
-
-                      Ok(format!("{} as {}", expr_str, ty_str))
+                      Ok(format!("{}{}{}{}{}", prefix, lhs_str, infix, rhs_str, suffix))
                   })
 }
 
@@ -635,33 +590,6 @@ fn rewrite_label(label: Option<ast::Ident>) -> String {
         Some(ident) => format!("{}: ", ident),
         None => "".to_owned(),
     }
-}
-
-// FIXME: this doesn't play well with line breaks
-fn rewrite_range(context: &RewriteContext,
-                 left: Option<&ast::Expr>,
-                 right: Option<&ast::Expr>,
-                 width: usize,
-                 offset: Indent)
-                 -> Option<String> {
-    let left_string = match left {
-        Some(expr) => {
-            // 2 = ..
-            let max_width = try_opt!(width.checked_sub(2));
-            try_opt!(expr.rewrite(context, max_width, offset))
-        }
-        None => String::new(),
-    };
-
-    let right_string = match right {
-        Some(expr) => {
-            let max_width = try_opt!(width.checked_sub(left_string.len() + 2));
-            try_opt!(expr.rewrite(context, max_width, offset + 2 + left_string.len()))
-        }
-        None => String::new(),
-    };
-
-    Some(format!("{}..{}", left_string, right_string))
 }
 
 // Rewrites if-else blocks. If let Some(_) = pat, the expression is

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -756,7 +756,7 @@ fn rewrite_match_arm_comment(context: &RewriteContext,
                              -> Option<String> {
     // The leading "," is not part of the arm-comment
     let missed_str = match missed_str.find_uncommented(",") {
-        Some(n) => &missed_str[n+1..],
+        Some(n) => &missed_str[n + 1..],
         None => &missed_str[..],
     };
 
@@ -816,7 +816,7 @@ fn rewrite_match(context: &RewriteContext,
         let missed_str = if i == 0 {
             context.snippet(mk_sp(open_brace_pos, arm_start_pos(arm)))
         } else {
-            context.snippet(mk_sp(arm_end_pos(&arms[i-1]), arm_start_pos(arm)))
+            context.snippet(mk_sp(arm_end_pos(&arms[i - 1]), arm_start_pos(arm)))
         };
         let comment = try_opt!(rewrite_match_arm_comment(context,
                                                          &missed_str,

--- a/src/items.rs
+++ b/src/items.rs
@@ -476,7 +476,7 @@ impl<'a> FmtVisitor<'a> {
             };
 
             let more_items = itemize_list(self.codemap,
-                                          args[min_args-1..].iter(),
+                                          args[min_args - 1..].iter(),
                                           ")",
                                           |arg| span_lo_for_arg(arg),
                                           |arg| arg.ty.span.hi,

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -379,7 +379,7 @@ impl<'a, T, I, F1, F2, F3> Iterator for ListItems<'a, I, F1, F2, F3>
                 // because of the way we divide pre- and post- comments.
 
                 // Everything from the separator to the next item.
-                let test_snippet = &post_snippet[comment_end-1..];
+                let test_snippet = &post_snippet[comment_end - 1..];
                 let first_newline = test_snippet.find('\n').unwrap_or(test_snippet.len());
                 // From the end of the first line of comments.
                 let test_snippet = &test_snippet[first_newline..];

--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -78,7 +78,7 @@ impl<'a> FmtVisitor<'a> {
                     self.buffer.push_str(&snippet[line_start..lw]);
                     self.buffer.push_str("\n");
                 } else {
-                    self.buffer.push_str(&snippet[line_start..i+1]);
+                    self.buffer.push_str(&snippet[line_start..i + 1]);
                 }
 
                 line_start = i + 1;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -407,7 +407,7 @@ impl<'a> Rewrite for [ast::Attribute] {
             let a_str = context.snippet(a.span);
 
             if i > 0 {
-                let comment = context.snippet(codemap::mk_sp(self[i-1].span.hi, a.span.lo));
+                let comment = context.snippet(codemap::mk_sp(self[i - 1].span.hi, a.span.lo));
                 // This particular horror show is to preserve line breaks in between doc
                 // comments. An alternative would be to force such line breaks to start
                 // with the usual doc comment token.

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -202,3 +202,8 @@ fn indices() {
     let x = (aaaaaaaaaaaaaaaaaaaaaaaaaaaa+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb+cccccccccccccccc) [ x + y + z ];
     let y = (aaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb + cccccccccccccccc)[ xxxxx + yyyyy + zzzzz ];
 }
+
+fn repeats() {
+    let x = [aaaaaaaaaaaaaaaaaaaaaaaaaaaa+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb+cccccccccccccccc; x + y + z ];
+    let y = [aaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb + cccccccccccccccc; xxxxx + yyyyy + zzzzz ];
+}

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -197,3 +197,8 @@ fn casts() {
         as SomeTraitXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;
     let slightly_longer_trait = yyyyyyyyy + yyyyyyyyyyy as SomeTraitYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY;
 }
+
+fn indices() {
+    let x = (aaaaaaaaaaaaaaaaaaaaaaaaaaaa+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb+cccccccccccccccc) [ x + y + z ];
+    let y = (aaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb + cccccccccccccccc)[ xxxxx + yyyyy + zzzzz ];
+}

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -184,3 +184,16 @@ fn addrof() {
     &    mut(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb);
     &    (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb);
 }
+
+fn casts() {
+    fn unpack(packed: u32) -> [u16; 2] {
+        [
+            (packed >> 16) as u16,
+            (packed >>  0) as u16,
+        ]
+    }
+
+    let some_trait_xxx = xxxxxxxxxxx + xxxxxxxxxxxxx
+        as SomeTraitXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;
+    let slightly_longer_trait = yyyyyyyyy + yyyyyyyyyyy as SomeTraitYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY;
+}

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -198,3 +198,13 @@ fn addrof() {
     &(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa +
       bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb);
 }
+
+fn casts() {
+    fn unpack(packed: u32) -> [u16; 2] {
+        [(packed >> 16) as u16, (packed >> 0) as u16]
+    }
+
+    let some_trait_xxx = xxxxxxxxxxx + xxxxxxxxxxxxx as SomeTraitXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX;
+    let slightly_longer_trait = yyyyyyyyy +
+                                yyyyyyyyyyy as SomeTraitYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY;
+}

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -216,3 +216,11 @@ fn indices() {
     let y = (aaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb +
              cccccccccccccccc)[xxxxx + yyyyy + zzzzz];
 }
+
+fn repeats() {
+    let x = [aaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb + cccccccccccccccc; x +
+                                                                                                y +
+                                                                                                z];
+    let y = [aaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb +
+             cccccccccccccccc; xxxxx + yyyyy + zzzzz];
+}

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -208,3 +208,11 @@ fn casts() {
     let slightly_longer_trait = yyyyyyyyy +
                                 yyyyyyyyyyy as SomeTraitYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY;
 }
+
+fn indices() {
+    let x = (aaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb + cccccccccccccccc)[x +
+                                                                                                y +
+                                                                                                z];
+    let y = (aaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb +
+             cccccccccccccccc)[xxxxx + yyyyy + zzzzz];
+}


### PR DESCRIPTION
Closes https://github.com/nrc/rustfmt/issues/395 and possibly https://github.com/nrc/rustfmt/issues/4. Maybe even https://github.com/nrc/rustfmt/issues/26?

Pretty much all expressions are deeply rewritten at this point. We only skip some types of literals and inline ASM.