### PR TITLE
List formatting refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,11 @@
 name = "rustfmt"
 version = "0.0.1"
 dependencies = [
- "diff 0.1.5 (git+https://github.com/utkarshkukreti/diff.rs.git)",
+ "diff 0.1.7 (git+https://github.com/utkarshkukreti/diff.rs.git)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "strings 0.0.1 (git+https://github.com/nrc/strings.rs.git)",
- "term 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -21,15 +21,15 @@ dependencies = [
 
 [[package]]
 name = "diff"
-version = "0.1.5"
-source = "git+https://github.com/utkarshkukreti/diff.rs.git#1921576a73e1b50a0ecb26c8ce62eefb26d273b4"
+version = "0.1.7"
+source = "git+https://github.com/utkarshkukreti/diff.rs.git#6edb9454bf4127087aced0fe07ab3ea6894083cb"
 
 [[package]]
 name = "kernel32-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -84,11 +84,11 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -106,7 +106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -348,8 +348,7 @@ mod test {
         assert_eq!(&uncommented("abc/*...*/"), "abc");
         assert_eq!(&uncommented("// .... /* \n../* /* *** / */ */a/* // */c\n"),
                    "..ac\n");
-        assert_eq!(&uncommented("abc \" /* */\" qsdf"),
-                   "abc \" /* */\" qsdf");
+        assert_eq!(&uncommented("abc \" /* */\" qsdf"), "abc \" /* */\" qsdf");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -260,7 +260,7 @@ create_config! {
     max_width: usize, 100, "Maximum width of each line";
     ideal_width: usize, 80, "Ideal width of each line";
     tab_spaces: usize, 4, "Number of spaces per tab";
-    fn_call_width: usize, 55,
+    fn_call_width: usize, 60,
         "Maximum width of the args of a function call before faling back to vertical formatting";
     struct_lit_width: usize, 16,
         "Maximum width in the body of a struct lit before faling back to vertical formatting";

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,7 +90,6 @@ configuration_option_enum! { LicensePolicy:
     FileLicense,
 }
 
-// TODO: this is not necessary any more
 configuration_option_enum! { MultilineStyle:
     // Use horizontal layout if it fits in one line, fall back to vertical
     PreferSingle,

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,7 @@ configuration_option_enum! { LicensePolicy:
     FileLicense,
 }
 
+// TODO: this is not necessary any more
 configuration_option_enum! { MultilineStyle:
     // Use horizontal layout if it fits in one line, fall back to vertical
     PreferSingle,
@@ -260,9 +261,9 @@ create_config! {
     max_width: usize, 100, "Maximum width of each line";
     ideal_width: usize, 80, "Ideal width of each line";
     tab_spaces: usize, 4, "Number of spaces per tab";
-    fn_call_width: usize, 50,
+    fn_call_width: usize, 55,
         "Maximum width of the args of a function call before faling back to vertical formatting";
-    struct_lit_width: usize, 12,
+    struct_lit_width: usize, 16,
         "Maximum width in the body of a struct lit before faling back to vertical formatting";
     newline_style: NewlineStyle, NewlineStyle::Unix, "Unix or Windows line endings";
     fn_brace_style: BraceStyle, BraceStyle::SameLineWhere, "Brace style for functions";

--- a/src/filemap.rs
+++ b/src/filemap.rs
@@ -115,8 +115,7 @@ fn write_file(text: &StringBuffer,
             try!(write_system_newlines(&mut v, text, config));
             let fmt_text = String::from_utf8(v).unwrap();
             let diff = make_diff(&ori_text, &fmt_text, 3);
-            print_diff(diff,
-                       |line_num| format!("\nDiff at line {}:", line_num));
+            print_diff(diff, |line_num| format!("\nDiff at line {}:", line_num));
         }
         WriteMode::Return => {
             // io::Write is not implemented for String, working around with

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use Indent;
-use lists::{write_list, itemize_list, ListItem, ListFormatting, SeparatorTactic};
+use lists::{write_list, itemize_list, ListItem, ListFormatting, SeparatorTactic, definitive_tactic};
 use utils::span_after;
 use rewrite::{Rewrite, RewriteContext};
 
@@ -153,9 +153,9 @@ pub fn rewrite_use_list(width: usize,
         items[1..].sort_by(|a, b| a.item.cmp(&b.item));
     }
 
-    let tactic = ::lists::definitive_tactic(&items[first_index..],
-                                            ::lists::ListTactic::Mixed,
-                                            remaining_width);
+    let tactic = definitive_tactic(&items[first_index..],
+                                   ::lists::ListTactic::Mixed,
+                                   remaining_width);
     let fmt = ListFormatting {
         tactic: tactic,
         separator: ",",

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -71,7 +71,7 @@ fn rewrite_single_use_list(path_str: String, vpi: &ast::PathListItem) -> String 
     append_alias(path_item_str, vpi)
 }
 
-fn rewrite_path_item(vpi: &&ast::PathListItem) -> String {
+fn rewrite_path_item(vpi: &&ast::PathListItem) -> Option<String> {
     let path_item_str = match vpi.node {
         ast::PathListItem_::PathListIdent{ name, .. } => {
             name.to_string()
@@ -81,7 +81,7 @@ fn rewrite_path_item(vpi: &&ast::PathListItem) -> String {
         }
     };
 
-    append_alias(path_item_str, vpi)
+    Some(append_alias(path_item_str, vpi))
 }
 
 fn append_alias(path_item_str: String, vpi: &ast::PathListItem) -> String {
@@ -142,8 +142,6 @@ pub fn rewrite_use_list(width: usize,
     // We prefixed the item list with a dummy value so that we can
     // potentially move "self" to the front of the vector without touching
     // the rest of the items.
-    // FIXME: Make more efficient by using a linked list? That would require
-    // changes to the signatures of write_list.
     let has_self = move_self_to_front(&mut items);
     let first_index = if has_self {
         0
@@ -181,7 +179,7 @@ pub fn rewrite_use_list(width: usize,
 
 // Returns true when self item was found.
 fn move_self_to_front(items: &mut Vec<ListItem>) -> bool {
-    match items.iter().position(|item| item.item == "self") {
+    match items.iter().position(|item| item.item.as_ref().map(|x| &x[..]) == Some("self")) {
         Some(pos) => {
             items[0] = items.remove(pos);
             true

--- a/src/issues.rs
+++ b/src/issues.rs
@@ -236,8 +236,7 @@ fn find_unnumbered_issue() {
 
     fn check_pass(text: &str) {
         let mut seeker = BadIssueSeeker::new(ReportTactic::Unnumbered, ReportTactic::Unnumbered);
-        assert_eq!(None,
-                   text.chars().position(|c| seeker.inspect(c).is_some()));
+        assert_eq!(None, text.chars().position(|c| seeker.inspect(c).is_some()));
     }
 
     check_fail("TODO\n", 4);
@@ -272,9 +271,7 @@ fn find_issue() {
                          ReportTactic::Never,
                          ReportTactic::Always));
 
-    assert!(!is_bad_issue("bad FIXME\n",
-                          ReportTactic::Always,
-                          ReportTactic::Never));
+    assert!(!is_bad_issue("bad FIXME\n", ReportTactic::Always, ReportTactic::Never));
 }
 
 #[test]

--- a/src/items.rs
+++ b/src/items.rs
@@ -312,9 +312,7 @@ impl<'a> FmtVisitor<'a> {
 
         let context = self.get_context();
         let ret_str = fd.output
-                        .rewrite(&context,
-                                 self.config.max_width - indent.width(),
-                                 indent)
+                        .rewrite(&context, self.config.max_width - indent.width(), indent)
                         .unwrap();
 
         // Args.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,7 @@ impl Indent {
 
     pub fn to_string(&self, config: &Config) -> String {
         let (num_tabs, num_spaces) = if config.hard_tabs {
-            (self.block_indent / config.tab_spaces,
-             self.alignment)
+            (self.block_indent / config.tab_spaces, self.alignment)
         } else {
             (0, self.block_indent + self.alignment)
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@
 // keeping some scratch mem for this and running our own StrPool?
 // TODO for lint violations of names, emit a refactor script
 
-
 #[macro_use]
 extern crate log;
 

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -19,12 +19,15 @@ use comment::{FindUncommented, rewrite_comment, find_comment_end};
 use config::Config;
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
+/// Formatting tactic for lists. This will be cast down to a
+/// DefinitiveListTactic depending on the number and length of the items and
+/// their comments.
 pub enum ListTactic {
     // One item per row.
     Vertical,
     // All items on one row.
     Horizontal,
-    // Try Horizontal layout, if that fails then vertical
+    // Try Horizontal layout, if that fails then vertical.
     HorizontalVertical,
     // HorizontalVertical with a soft limit of n characters.
     LimitedHorizontalVertical(usize),
@@ -72,11 +75,7 @@ pub fn format_item_list<I>(items: I,
                            -> Option<String>
     where I: Iterator<Item = ListItem>
 {
-    list_helper(items,
-                width,
-                offset,
-                config,
-                ListTactic::HorizontalVertical)
+    list_helper(items, width, offset, config, ListTactic::HorizontalVertical)
 }
 
 fn list_helper<I>(items: I,
@@ -111,7 +110,7 @@ impl AsRef<ListItem> for ListItem {
 pub struct ListItem {
     // None for comments mean that they are not present.
     pub pre_comment: Option<String>,
-    // Item should include attributes and doc comments. None indicates failed
+    // Item should include attributes and doc comments. None indicates a failed
     // rewrite.
     pub item: Option<String>,
     pub post_comment: Option<String>,
@@ -121,7 +120,6 @@ pub struct ListItem {
 
 impl ListItem {
     pub fn is_multiline(&self) -> bool {
-        // FIXME: fail earlier!
         self.item.as_ref().map(|s| s.contains('\n')).unwrap_or(false) ||
         self.pre_comment.is_some() ||
         self.post_comment.as_ref().map(|s| s.contains('\n')).unwrap_or(false)
@@ -142,6 +140,7 @@ impl ListItem {
 }
 
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
+/// The definitive formatting tactic for lists.
 pub enum DefinitiveListTactic {
     Vertical,
     Horizontal,
@@ -488,8 +487,6 @@ fn calculate_width<'li, I, T>(items: I) -> (usize, usize)
 }
 
 fn total_item_width(item: &ListItem) -> usize {
-    // FIXME: If the item has a `None` item, it may be better to fail earlier
-    // rather than later.
     comment_len(item.pre_comment.as_ref().map(|x| &(*x)[..])) +
     comment_len(item.post_comment.as_ref().map(|x| &(*x)[..])) +
     item.item.as_ref().map(|str| str.len()).unwrap_or(0)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -89,7 +89,12 @@ pub fn rewrite_macro(mac: &ast::Mac,
     match style {
         MacroStyle::Parens => {
             // Format macro invocation as function call.
-            rewrite_call(context, &macro_name, &expr_vec, mac.span, width, offset)
+            rewrite_call(context,
+                         &macro_name,
+                         &expr_vec,
+                         mac.span,
+                         width,
+                         offset)
         }
         MacroStyle::Brackets => {
             // Format macro invocation as array literal.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -89,12 +89,7 @@ pub fn rewrite_macro(mac: &ast::Mac,
     match style {
         MacroStyle::Parens => {
             // Format macro invocation as function call.
-            rewrite_call(context,
-                         &macro_name,
-                         &expr_vec,
-                         mac.span,
-                         width,
-                         offset)
+            rewrite_call(context, &macro_name, &expr_vec, mac.span, width, offset)
         }
         MacroStyle::Brackets => {
             // Format macro invocation as array literal.

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ use syntax::print::pprust;
 use syntax::codemap::{self, Span, BytePos, CodeMap};
 
 use Indent;
-use lists::itemize_list;
+use lists::{format_item_list, itemize_list, format_fn_args};
 use rewrite::{Rewrite, RewriteContext};
 use utils::{extra_offset, span_after, format_mutability, wrap_str};
 
@@ -226,10 +226,10 @@ fn rewrite_segment(segment: &ast::PathSegment,
                                      },
                                      list_lo,
                                      span_hi);
-            let list_str = try_opt!(::lists::format_item_list(items,
-                                                              list_width,
-                                                              offset + extra_offset,
-                                                              context.config));
+            let list_str = try_opt!(format_item_list(items,
+                                                     list_width,
+                                                     offset + extra_offset,
+                                                     context.config));
 
             // Update position of last bracket.
             *span_lo = next_span_lo;
@@ -258,7 +258,7 @@ fn rewrite_segment(segment: &ast::PathSegment,
                                      |ty| ty.rewrite(context, budget, offset),
                                      list_lo,
                                      span_hi);
-            let list_str = try_opt!(::lists::format_fn_args(items, budget, offset, context.config));
+            let list_str = try_opt!(format_fn_args(items, budget, offset, context.config));
 
             format!("({}){}", list_str, output)
         }
@@ -363,8 +363,7 @@ impl Rewrite for ast::TyParamBound {
             }
             ast::TyParamBound::TraitTyParamBound(ref tref, ast::TraitBoundModifier::Maybe) => {
                 let budget = try_opt!(width.checked_sub(1));
-                Some(format!("?{}",
-                             try_opt!(tref.rewrite(context, budget, offset + 1))))
+                Some(format!("?{}", try_opt!(tref.rewrite(context, budget, offset + 1))))
             }
             ast::TyParamBound::RegionTyParamBound(ref l) => {
                 Some(pprust::lifetime_to_string(l))

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ use syntax::print::pprust;
 use syntax::codemap::{self, Span, BytePos, CodeMap};
 
 use Indent;
-use lists::{itemize_list, write_list, ListFormatting};
+use lists::itemize_list;
 use rewrite::{Rewrite, RewriteContext};
 use utils::{extra_offset, span_after, format_mutability, wrap_str};
 
@@ -206,9 +206,7 @@ fn rewrite_segment(segment: &ast::PathSegment,
                                  .collect::<Vec<_>>();
 
             let next_span_lo = param_list.last().unwrap().get_span().hi + BytePos(1);
-            let list_lo = span_after(codemap::mk_sp(*span_lo, span_hi),
-                                     "<",
-                                     context.codemap);
+            let list_lo = span_after(codemap::mk_sp(*span_lo, span_hi), "<", context.codemap);
             let separator = get_path_separator(context.codemap, *span_lo, list_lo);
 
             // 1 for <
@@ -232,9 +230,10 @@ fn rewrite_segment(segment: &ast::PathSegment,
                                      },
                                      list_lo,
                                      span_hi);
-
-            let fmt = ListFormatting::for_item(list_width, offset + extra_offset, context.config);
-            let list_str = try_opt!(write_list(&items.collect::<Vec<_>>(), &fmt));
+            let list_str = try_opt!(::lists::format_item_list(items,
+                                                              list_width,
+                                                              offset + extra_offset,
+                                                              context.config));
 
             // Update position of last bracket.
             *span_lo = next_span_lo;
@@ -263,9 +262,7 @@ fn rewrite_segment(segment: &ast::PathSegment,
                                      |ty| ty.rewrite(context, budget, offset).unwrap(),
                                      list_lo,
                                      span_hi);
-
-            let fmt = ListFormatting::for_fn(budget, offset, context.config);
-            let list_str = try_opt!(write_list(&items.collect::<Vec<_>>(), &fmt));
+            let list_str = try_opt!(::lists::format_fn_args(items, budget, offset, context.config));
 
             format!("({}){}", list_str, output)
         }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -319,9 +319,7 @@ impl<'a> FmtVisitor<'a> {
     }
 
     fn format_mod(&mut self, m: &ast::Mod, s: Span, ident: ast::Ident) {
-        debug!("FmtVisitor::format_mod: ident: {:?}, span: {:?}",
-               ident,
-               s);
+        debug!("FmtVisitor::format_mod: ident: {:?}, span: {:?}", ident, s);
 
         // Decide whether this is an inline mod or an external mod.
         let local_file_name = self.codemap.span_to_filename(s);
@@ -359,9 +357,7 @@ impl<'a> FmtVisitor<'a> {
             overflow_indent: Indent::empty(),
         };
         // 1 = ";"
-        match vp.rewrite(&context,
-                         self.config.max_width - offset.width() - 1,
-                         offset) {
+        match vp.rewrite(&context, self.config.max_width - offset.width() - 1, offset) {
             Some(ref s) if s.is_empty() => {
                 // Format up to last newline
                 let prev_span = codemap::mk_sp(self.last_pos, span.lo);


### PR DESCRIPTION
This PR does several things. 

- It moves the list tactic decision logic to its own function. As a result, it should become easier to implement custom logic for issues such as https://github.com/nrc/rustfmt/issues/263. It's now also possible to do list itemization and serialization, e.g. `itemize_list` and `write_list`, without storing the intermediate results in a vector.

- It adds a failure mode to `ListItem`. Failures to rewrite list items need no longer result in panics, but can be gracefully handled as we do other rewrite failures. This addresses parts of https://github.com/nrc/rustfmt/issues/133.

- Take into account the length of the separators for the line splitting heuristic in functions and items. To compensate for this, the limits have been raised from 50 to 55 and from 12 to 16 for functions and items respectively.

This is a WIP, as a number of things need more elegant solutions and it'd be nice if we could do allocation free list rewrites in more cases.