### PR TITLE
Format inner and outer attributes separately.

### DIFF
--- a/tests/target/fn.rs
+++ b/tests/target/fn.rs
@@ -87,3 +87,9 @@ fn main() {
     let _ = move || 42;
     let _ = || unsafe { abort() };
 }
+
+// With inner attributes.
+fn inner() {
+    #![inline]
+    x
+}


### PR DESCRIPTION
Actually just skips inner attributes, because its a pain to track them, and lets missed spans handle them.

Closes #413