### PR TITLE
Try "overflowing" the final function argument when it's a closure

### DIFF
--- a/src/missed_spans.rs
+++ b/src/missed_spans.rs
@@ -22,16 +22,15 @@ impl<'a> FmtVisitor<'a> {
 
     pub fn format_missing_with_indent(&mut self, end: BytePos) {
         let config = self.config;
-        self.format_missing_inner(end,
-                                  |this, last_snippet, snippet| {
-                                      this.buffer.push_str(last_snippet.trim_right());
-                                      if last_snippet == snippet {
-                                          // No new lines in the snippet.
-                                          this.buffer.push_str("\n");
-                                      }
-                                      let indent = this.block_indent.to_string(config);
-                                      this.buffer.push_str(&indent);
-                                  })
+        self.format_missing_inner(end, |this, last_snippet, snippet| {
+            this.buffer.push_str(last_snippet.trim_right());
+            if last_snippet == snippet {
+                // No new lines in the snippet.
+                this.buffer.push_str("\n");
+            }
+            let indent = this.block_indent.to_string(config);
+            this.buffer.push_str(&indent);
+        })
     }
 
     fn format_missing_inner<F: Fn(&mut FmtVisitor, &str, &str)>(&mut self,

--- a/tests/source/chains.rs
+++ b/tests/source/chains.rs
@@ -23,6 +23,20 @@ fn main() {
             2
         });
 
+    some_fuuuuuuuuunction()
+        .method_call_a(aaaaa, bbbbb, |c| {
+            let x = c;
+            x
+        });
+
+    some_fuuuuuuuuunction().method_call_a(aaaaa, bbbbb, |c| {
+        let x = c;
+        x
+    }).method_call_b(aaaaa, bbbbb, |c| {
+        let x = c;
+        x
+    });
+
     fffffffffffffffffffffffffffffffffff(a,
                                         {
                                             SCRIPT_TASK_ROOT

--- a/tests/target/chains.rs
+++ b/tests/target/chains.rs
@@ -30,12 +30,26 @@ fn main() {
         }
     });
 
-    fffffffffffffffffffffffffffffffffff(a,
-                                        {
-                                            SCRIPT_TASK_ROOT.with(|root| {
-                                                *root.borrow_mut() = Some(&script_task);
-                                            });
-                                        });
+    some_fuuuuuuuuunction().method_call_a(aaaaa, bbbbb, |c| {
+        let x = c;
+        x
+    });
+
+    some_fuuuuuuuuunction()
+        .method_call_a(aaaaa, bbbbb, |c| {
+            let x = c;
+            x
+        })
+        .method_call_b(aaaaa, bbbbb, |c| {
+            let x = c;
+            x
+        });
+
+    fffffffffffffffffffffffffffffffffff(a, {
+        SCRIPT_TASK_ROOT.with(|root| {
+            *root.borrow_mut() = Some(&script_task);
+        });
+    });
 
     let suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuum = xxxxxxx.map(|x| x + 5)
                                                                           .map(|x| x / 2)

--- a/tests/target/hard-tabs.rs
+++ b/tests/target/hard-tabs.rs
@@ -76,12 +76,11 @@ fn main() {
 		}
 	});
 
-	fffffffffffffffffffffffffffffffffff(a,
-	                                    {
-		                                    SCRIPT_TASK_ROOT.with(|root| {
-			                                    *root.borrow_mut() = Some(&script_task);
-		                                    });
-	                                    });
+	fffffffffffffffffffffffffffffffffff(a, {
+		SCRIPT_TASK_ROOT.with(|root| {
+			*root.borrow_mut() = Some(&script_task);
+		});
+	});
 	a.b
 	 .c
 	 .d();


### PR DESCRIPTION
This means that we try formatting the last argument of a function call with block indentation instead of visual indentation when it is a closure and its first line fits on the same line as the first arguments.

This closes https://github.com/nrc/rustfmt/issues/263.