### PR TITLE
Fix Build to Compile with 1.5.0-nightly (87cd2c082)

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -113,7 +113,7 @@ impl Rewrite for ast::Expr {
                                 offset,
                                 true)
             }
-            ast::Expr_::ExprMatch(ref cond, ref arms, _) => {
+            ast::Expr_::ExprMatch(ref cond, ref arms) => {
                 rewrite_match(context, cond, arms, width, offset, self.span)
             }
             ast::Expr_::ExprPath(ref qself, ref path) => {


### PR DESCRIPTION
There was an extra, unused, paramter int he match arm which causes an
error when compiling with the latest nightly.