### PR TITLE
Use visual block indentation for array literals

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -256,6 +256,8 @@ pub fn rewrite_array<'a, I>(expr_iter: I,
     where I: Iterator<Item = &'a ast::Expr>
 {
     // 2 for brackets;
+    let offset = offset + 1;
+    let inner_context = &RewriteContext { block_indent: offset, ..*context };
     let max_item_width = try_opt!(width.checked_sub(2));
     let items = itemize_list(context.codemap,
                              expr_iter,
@@ -263,7 +265,7 @@ pub fn rewrite_array<'a, I>(expr_iter: I,
                              |item| item.span.lo,
                              |item| item.span.hi,
                              // 1 = [
-                             |item| item.rewrite(context, max_item_width, offset + 1),
+                             |item| item.rewrite(&inner_context, max_item_width, offset),
                              span_after(span, "[", context.codemap),
                              span.hi)
                     .collect::<Vec<_>>();
@@ -283,7 +285,7 @@ pub fn rewrite_array<'a, I>(expr_iter: I,
         tactic: tactic,
         separator: ",",
         trailing_separator: SeparatorTactic::Never,
-        indent: offset + 1,
+        indent: offset,
         width: max_item_width,
         ends_with_newline: false,
         config: context.config,

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -169,6 +169,25 @@ fn arrays() {
 
     let y = [/* comment */ 1, 2 /* post comment */, 3];
 
+    let xy =    [ strukt  { test123: value_one_two_three_four, turbo: coolio(), } , /* comment  */   1 ];
+
+        let a =WeightedChoice::new(&mut [Weighted {
+            weight: x,
+            item: 0,
+        },
+                                  Weighted {
+            weight: 1,
+            item: 1,
+        },
+                                  Weighted {
+            weight: x,
+            item: 2,
+        },
+                                  Weighted {
+            weight: 1,
+            item: 3,
+        }]);
+
     let z = [xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, yyyyyyyyyyyyyyyyyyyyyyyyyyy, zzzzzzzzzzzzzzzzzz, q];
 
     [ 1 +   3, 4 ,  5, 6, 7, 7, fncall::<Vec<_>>(3-1)]

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -176,6 +176,30 @@ fn arrays() {
              2, // post comment
              3];
 
+    let xy = [strukt {
+                  test123: value_one_two_three_four,
+                  turbo: coolio(),
+              },
+              // comment
+              1];
+
+    let a = WeightedChoice::new(&mut [Weighted {
+                                          weight: x,
+                                          item: 0,
+                                      },
+                                      Weighted {
+                                          weight: 1,
+                                          item: 1,
+                                      },
+                                      Weighted {
+                                          weight: x,
+                                          item: 2,
+                                      },
+                                      Weighted {
+                                          weight: 1,
+                                          item: 3,
+                                      }]);
+
     let z = [xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
              yyyyyyyyyyyyyyyyyyyyyyyyyyy,
              zzzzzzzzzzzzzzzzzz,


### PR DESCRIPTION
This fixes https://github.com/nrc/rustfmt/issues/440.