### PR TITLE
Issue353

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -812,7 +812,7 @@ fn rewrite_match(context: &RewriteContext,
 fn arm_start_pos(arm: &ast::Arm) -> BytePos {
     let &ast::Arm { ref attrs, ref pats, .. } = arm;
     if !attrs.is_empty() {
-        return attrs[0].span.lo
+        return attrs[0].span.lo;
     }
 
     pats[0].span.lo

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -70,7 +70,7 @@ fn bar() {
     let bar = 5 ;
     let nonsense = (10 .. 0)..(0..10);
 
-    loop{if true {break}}
+    loop{if true {break;}}
 
     let x = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -105,7 +105,7 @@ fn bar() {
 
     loop {
         if true {
-            break
+            break;
         }
     }
 


### PR DESCRIPTION
fixes #353 ; now all return, continue and break statements have semi-colons at their end.