### PR TITLE
Indent uncontinued chains to block level

### DIFF
--- a/src/chains.rs
+++ b/src/chains.rs
@@ -45,13 +45,13 @@ pub fn rewrite_chain(mut expr: &ast::Expr,
     let parent_rewrite = try_opt!(expr.rewrite(context, width, offset));
     let (extra_indent, extend) = if !parent_rewrite.contains('\n') && is_continuable(parent) ||
                                     parent_rewrite.len() <= context.config.tab_spaces {
-        (parent_rewrite.len(), true)
+        (Indent::new(0, parent_rewrite.len()), true)
     } else {
-        (context.config.tab_spaces, false)
+        (Indent::new(context.config.tab_spaces, 0), false)
     };
     let indent = offset + extra_indent;
 
-    let max_width = try_opt!(width.checked_sub(extra_indent));
+    let max_width = try_opt!(width.checked_sub(extra_indent.width()));
     let mut rewrites = try_opt!(subexpr_list.iter()
                                             .rev()
                                             .map(|e| {

--- a/tests/source/hard-tabs.rs
+++ b/tests/source/hard-tabs.rs
@@ -31,6 +31,8 @@ unsafe // So this is a very long comment.
 {
 }
 
+let chain = funktion_kall().go_to_next_line_with_tab().go_to_next_line_with_tab().go_to_next_line_with_tab();
+
 let z = [xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx, yyyyyyyyyyyyyyyyyyyyyyyyyyy, zzzzzzzzzzzzzzzzzz, q];
 
 fn generic<T>(arg: T) -> &SomeType

--- a/tests/target/hard-tabs.rs
+++ b/tests/target/hard-tabs.rs
@@ -50,6 +50,11 @@ fn main() {
 	        * Will it still format correctly? */ {
 	}
 
+	let chain = funktion_kall()
+		            .go_to_next_line_with_tab()
+		            .go_to_next_line_with_tab()
+		            .go_to_next_line_with_tab();
+
 	let z = [xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx,
 	         yyyyyyyyyyyyyyyyyyyyyyyyyyy,
 	         zzzzzzzzzzzzzzzzzz,


### PR DESCRIPTION
Fixes one of the issues detailed in https://github.com/nrc/rustfmt/issues/454.