### PR TITLE
Force semicolons after break/continue/return. Remove after blocks.

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1322,7 +1322,7 @@ fn rewrite_struct_lit<'a>(context: &RewriteContext,
 
         if prelim_tactic == ListTactic::HorizontalVertical && fields.len() > 1 {
             prelim_tactic = ListTactic::LimitedHorizontalVertical(context.config.struct_lit_width);
-        };
+        }
 
         definitive_tactic(&item_vec, prelim_tactic, h_budget)
     };

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -70,7 +70,7 @@ fn bar() {
     let bar = 5 ;
     let nonsense = (10 .. 0)..(0..10);
 
-    loop{if true {break;}}
+    loop{if true {break}}
 
     let x = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa &&
              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,
@@ -225,4 +225,10 @@ fn indices() {
 fn repeats() {
     let x = [aaaaaaaaaaaaaaaaaaaaaaaaaaaa+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb+cccccccccccccccc; x + y + z ];
     let y = [aaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb + cccccccccccccccc; xxxxx + yyyyy + zzzzz ];
+}
+
+fn blocks() {
+    if 1 + 1 == 2 {
+        println!("yay arithmetix!");
+    };
 }

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -40,7 +40,7 @@ fn foo() -> bool {
         result
     } else {
         4
-    };
+    }
 
     if let Some(x) = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
         // Nothing
@@ -247,4 +247,10 @@ fn repeats() {
                                                                                                 z];
     let y = [aaaaaaaaaaaaaaaaaaaaaaaaaaaa + bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb +
              cccccccccccccccc; xxxxx + yyyyy + zzzzz];
+}
+
+fn blocks() {
+    if 1 + 1 == 2 {
+        println!("yay arithmetix!");
+    }
 }

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -215,5 +215,5 @@ fn issue383() {
     match resolution.last_private {
         LastImport{..} => false,
         _ => true,
-    };
+    }
 }


### PR DESCRIPTION
Close https://github.com/nrc/rustfmt/issues/422.
Close https://github.com/nrc/rustfmt/issues/353.