### PR TITLE
Refactor enum formatting

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -195,7 +195,13 @@ impl<'a, 'v> visit::Visitor<'v> for FmtVisitor<'a> {
                                                  def,
                                                  Some(generics),
                                                  item.span,
-                                                 indent);
+                                                 indent)
+                                  .map(|s| {
+                                      match **def {
+                                          ast::VariantData::Tuple(..) => s + ";",
+                                          _ => s,
+                                      }
+                                  });
                 self.push_rewrite(item.span, rewrite);
             }
             ast::Item_::ItemEnum(ref def, ref generics) => {

--- a/tests/source/enum.rs
+++ b/tests/source/enum.rs
@@ -92,3 +92,7 @@ fn nested_enum_test() {
         }
     }
 }
+
+   pub  struct  EmtpyWithComment {
+    // FIXME: Implement this struct
+}

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -115,3 +115,9 @@ struct FieldsWithAttributes {
     #[attr1]
     #[attr2] pub id: usize // CCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCC CCCCCCCCCCCC
 }
+
+struct Deep {
+    deeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeep: node::Handle<IdRef<'id, Node<K, V>>,
+                                                     Type,
+                                                     NodeType>,
+}

--- a/tests/target/enum.rs
+++ b/tests/target/enum.rs
@@ -140,3 +140,7 @@ fn nested_enum_test() {
         }
     }
 }
+
+pub struct EmtpyWithComment {
+    // FIXME: Implement this struct
+}

--- a/tests/target/structs.rs
+++ b/tests/target/structs.rs
@@ -34,12 +34,10 @@ struct Qux<'a,
     pub W,
 );
 
-struct Tuple(
-    // Comment 1
-    AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
-    // Comment 2
-    BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB,
-);
+struct Tuple(// Comment 1
+             AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA,
+             // Comment 2
+             BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB);
 
 // With a where clause and generics.
 pub struct Foo<'a, Y: Baz>
@@ -112,4 +110,10 @@ struct FieldsWithAttributes {
     #[attr2]
     pub id: usize, /* CCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCC CCCCCCCCCCCCCCCCCC
                     * CCCCCCCCCCCCCC CCCCCCCCCCCC */
+}
+
+struct Deep {
+    deeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeep: node::Handle<IdRef<'id, Node<K, V>>,
+                                                                         Type,
+                                                                         NodeType>,
 }


### PR DESCRIPTION
Unify formatting code for enum variants and structs.

Fix https://github.com/nrc/rustfmt/issues/406.