### PR TITLE
Create a binary from travis ci and so on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,28 @@
+sudo: false
 language: rust
 rust:
  - nightly
-
-sudo: false
+os:
+ - linux
+ - osx
 
 script:
  - cargo build
  - cargo test
+
+before_deploy:
+  # TODO: cross build
+ - cargo build --release --target=x86_64-unknown-linux-gnu
+ - tar czf rustfmt-x86_64-unknown-linux-gnu.tar.gz Contributing.md Design.md README.md -C target/x86_64-unknown-linux-gnu/release/rustfmt rustfmt
+
+deploy:
+  provider: releases
+  api_key:
+    secure: "your own encrypted key"
+  file:
+  - rustfmt-x86_64-unknown-linux-gnu.tar.gz
+  on:
+    repo: nrc/rustfmt
+    tags: true
+    condition: "$TRAVIS_OS_NAME = linux"
+  skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rustfmt
+# rustfmt [![Build Status](https://travis-ci.org/nrc/rustfmt.svg)](https://travis-ci.org/nrc/rustfmt)
 
 A tool for formatting Rust code according to style guidelines.
 


### PR DESCRIPTION
* Create release binaries when you created tags
* Build and test on OS X too (but archives aren't created)
* Add build status badge to README.md

You need to get API key for Github and encrypt it with travis CLI, then past it at `secure` section. (Supposing you have installed travis CLI, you can encrypt your API key with `travis encrypt -r nrc/rustfmt <API key>`.)

I tried to build binaries other than linux but

* Cross compilations aren't supported because you need to add some options when you build rust compilers
* You can't create release archives from multiple OS's because archive names conflicts at `file` section.

How do you like?