### PR TITLE
Format more type variants

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -161,10 +161,10 @@ impl Rewrite for ast::Expr {
                 wrap_str("return".to_owned(), context.config.max_width, width, offset)
             }
             ast::Expr_::ExprRet(Some(ref expr)) => {
-                rewrite_unary_prefix(context, "return ", expr, width, offset)
+                rewrite_unary_prefix(context, "return ", &**expr, width, offset)
             }
             ast::Expr_::ExprBox(ref expr) => {
-                rewrite_unary_prefix(context, "box ", expr, width, offset)
+                rewrite_unary_prefix(context, "box ", &**expr, width, offset)
             }
             ast::Expr_::ExprAddrOf(mutability, ref expr) => {
                 rewrite_expr_addrof(context, mutability, expr, width, offset)
@@ -210,15 +210,15 @@ impl Rewrite for ast::Expr {
     }
 }
 
-fn rewrite_pair<LHS, RHS>(lhs: &LHS,
-                          rhs: &RHS,
-                          prefix: &str,
-                          infix: &str,
-                          suffix: &str,
-                          context: &RewriteContext,
-                          width: usize,
-                          offset: Indent)
-                          -> Option<String>
+pub fn rewrite_pair<LHS, RHS>(lhs: &LHS,
+                              rhs: &RHS,
+                              prefix: &str,
+                              infix: &str,
+                              suffix: &str,
+                              context: &RewriteContext,
+                              width: usize,
+                              offset: Indent)
+                              -> Option<String>
     where LHS: Rewrite,
           RHS: Rewrite
 {
@@ -1470,16 +1470,16 @@ fn rewrite_binary_op(context: &RewriteContext,
                  rhs_result))
 }
 
-fn rewrite_unary_prefix(context: &RewriteContext,
-                        prefix: &str,
-                        expr: &ast::Expr,
-                        width: usize,
-                        offset: Indent)
-                        -> Option<String> {
-    expr.rewrite(context,
-                 try_opt!(width.checked_sub(prefix.len())),
-                 offset + prefix.len())
-        .map(|r| format!("{}{}", prefix, r))
+pub fn rewrite_unary_prefix<R: Rewrite>(context: &RewriteContext,
+                                        prefix: &str,
+                                        rewrite: &R,
+                                        width: usize,
+                                        offset: Indent)
+                                        -> Option<String> {
+    rewrite.rewrite(context,
+                    try_opt!(width.checked_sub(prefix.len())),
+                    offset + prefix.len())
+           .map(|r| format!("{}{}", prefix, r))
 }
 
 fn rewrite_unary_op(context: &RewriteContext,

--- a/src/items.rs
+++ b/src/items.rs
@@ -522,7 +522,7 @@ impl<'a> FmtVisitor<'a> {
 
             let variadic_arg = if variadic {
                 let variadic_span = codemap::mk_sp(args.last().unwrap().ty.span.hi, span.hi);
-                let variadic_start = span_after(variadic_span, "...", self.codemap) - BytePos(1);
+                let variadic_start = span_after(variadic_span, "...", self.codemap) - BytePos(3);
                 Some(ArgumentKind::Variadic(variadic_start))
             } else {
                 None

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,8 +32,9 @@ pub fn extra_offset(text: &str, offset: Indent) -> usize {
 #[inline]
 pub fn span_after(original: Span, needle: &str, codemap: &CodeMap) -> BytePos {
     let snippet = codemap.span_to_snippet(original).unwrap();
+    let offset = snippet.find_uncommented(needle).unwrap() + needle.len();
 
-    original.lo + BytePos(snippet.find_uncommented(needle).unwrap() as u32 + 1)
+    original.lo + BytePos(offset as u32)
 }
 
 #[inline]

--- a/tests/source/type.rs
+++ b/tests/source/type.rs
@@ -1,0 +1,5 @@
+fn types() {
+    let x: [ Vec   < _ > ] = [];
+    let y:  * mut [ SomeType ; konst_funk() ] = expr();
+    let z: (/*#digits*/ usize, /*exp*/ i16) = funk();
+}

--- a/tests/target/type.rs
+++ b/tests/target/type.rs
@@ -1,0 +1,5 @@
+fn types() {
+    let x: [Vec<_>] = [];
+    let y: *mut [SomeType; konst_funk()] = expr();
+    let z: (/* #digits */ usize, /* exp */ i16) = funk();
+}


### PR DESCRIPTION
Add formatting for almost all types. Only bare functions types are not formatted yet. We have a lot of function type formatting code already in function definitions and paths, it's just a matter of reusing that logic nicely now.

Also did some cleanups of instances where we assumed we wouldn't run over the width limit.