### PR TITLE
Deal with floaters

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -290,9 +290,10 @@ create_config! {
         "Multiline style on literal structs";
     enum_trailing_comma: bool, true, "Put a trailing comma on enum declarations";
     report_todo: ReportTactic, ReportTactic::Always,
-        "Report all occurrences of TODO in source file comments";
+        "Report all, none or unnumbered occurrences of TODO in source file comments";
     report_fixme: ReportTactic, ReportTactic::Never,
-        "Report all occurrences of FIXME in source file comments";
+        "Report all, none or unnumbered occurrences of FIXME in source file comments";
+    chain_base_indent: BlockIndentStyle, BlockIndentStyle::Visual, "Indent on chain base";
     // Alphabetically, case sensitive.
     reorder_imports: bool, false, "Reorder import statements alphabetically";
     single_line_if_else: bool, false, "Put else on same line as closing brace for if statements";

--- a/tests/source/chains-block-indented-base.rs
+++ b/tests/source/chains-block-indented-base.rs
@@ -1,0 +1,30 @@
+// rustfmt-chain_base_indent: Inherit
+// Test chain formatting with block indented base
+
+fn floaters() {
+    let x = Foo {
+                field1: val1,
+                field2: val2,
+            }
+            .method_call().method_call();
+
+    let y = if cond {
+                val1
+            } else {
+                val2
+            }
+                .method_call();
+
+    {
+        match x {
+            PushParam => {
+                // params are 1-indexed
+                stack.push(mparams[match cur.to_digit(10) {
+                                            Some(d) => d as usize - 1,
+                                            None => return Err("bad param number".to_owned()),
+                                        }]
+                               .clone());
+            }
+        }
+    }
+}

--- a/tests/source/chains.rs
+++ b/tests/source/chains.rs
@@ -55,3 +55,49 @@ fn main() {
                          x
                      }).filter(some_mod::some_filter)
 }
+
+fn floaters() {
+    let z = Foo {
+        field1: val1,
+        field2: val2,
+    };
+
+    let x = Foo {
+        field1: val1,
+        field2: val2,
+    }.method_call().method_call();
+
+    let y = if cond {
+                val1
+            } else {
+                val2
+            }
+                .method_call();
+
+    {
+        match x {
+            PushParam => {
+                // params are 1-indexed
+                stack.push(mparams[match cur.to_digit(10) {
+                    Some(d) => d as usize - 1,
+                    None => return Err("bad param number".to_owned()),
+                }]
+                               .clone());
+            }
+        }
+    }
+
+    if cond { some(); } else { none(); }
+        .bar()
+        .baz();
+
+    Foo { x: val } .baz(|| { /*force multiline    */    }) .quux(); 
+
+    Foo { y: i_am_multi_line, z: ok }
+        .baz(|| {
+            // force multiline
+        })
+        .quux(); 
+
+    a + match x { true => "yay!", false => "boo!" }.bar()
+}

--- a/tests/target/chains-block-indented-base.rs
+++ b/tests/target/chains-block-indented-base.rs
@@ -1,0 +1,31 @@
+// rustfmt-chain_base_indent: Inherit
+// Test chain formatting with block indented base
+
+fn floaters() {
+    let x = Foo {
+        field1: val1,
+        field2: val2,
+    }
+    .method_call()
+    .method_call();
+
+    let y = if cond {
+        val1
+    } else {
+        val2
+    }
+    .method_call();
+
+    {
+        match x {
+            PushParam => {
+                // params are 1-indexed
+                stack.push(mparams[match cur.to_digit(10) {
+                    Some(d) => d as usize - 1,
+                    None => return Err("bad param number".to_owned()),
+                }]
+                .clone());
+            }
+        }
+    }
+}

--- a/tests/target/chains.rs
+++ b/tests/target/chains.rs
@@ -62,3 +62,67 @@ fn main() {
                     })
                     .filter(some_mod::some_filter)
 }
+
+fn floaters() {
+    let z = Foo {
+        field1: val1,
+        field2: val2,
+    };
+
+    let x = Foo {
+                field1: val1,
+                field2: val2,
+            }
+            .method_call()
+            .method_call();
+
+    let y = if cond {
+                val1
+            } else {
+                val2
+            }
+            .method_call();
+
+    {
+        match x {
+            PushParam => {
+                // params are 1-indexed
+                stack.push(mparams[match cur.to_digit(10) {
+                               Some(d) => d as usize - 1,
+                               None => return Err("bad param number".to_owned()),
+                           }]
+                           .clone());
+            }
+        }
+    }
+
+    if cond {
+        some();
+    } else {
+        none();
+    }
+    .bar()
+    .baz();
+
+    Foo { x: val }
+        .baz(|| {
+            // force multiline
+        })
+        .quux();
+
+    Foo {
+        y: i_am_multi_line,
+        z: ok,
+    }
+    .baz(|| {
+        // force multiline
+    })
+    .quux();
+
+    a +
+    match x {
+        true => "yay!",
+        false => "boo!",
+    }
+    .bar()
+}


### PR DESCRIPTION
One of many possible approaches. I think this one is most in line with the way we format closures; block indentation if it's the last link in the call chain, visual otherwise.

Typical output with this strategy:
```rust
let x = match x {
            ...
        }
            .foo()
            .bar();
```

Other options to consider:
- format with block indent, continue chain on same line as closing brace/ parenthesis of parent
```rust
let x = match x {
    ...
}.foo()
 .bar();
```
- format with block indent, continue on next line with extra indentation
```rust
let x = match x {
    ...
}
    .foo()
    .bar();
```
- format with visual indentation, continue on next line without extra indentation
```rust
let x = match x {
            ...
        }
        .foo()
        .bar();
```
- format with block indentation, continue on next line without extra indentation
```rust
let x = match x {
    ...
}
.foo()
.bar();
```

Addresses https://github.com/nrc/rustfmt/issues/426.