### PR TITLE
Fix indentation for function arguments

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -481,7 +481,9 @@ impl<'a> FmtVisitor<'a> {
         let context = self.get_context();
         let mut arg_item_strs = try_opt!(args.iter()
                                              .map(|arg| {
-                                                 arg.rewrite(&context, multi_line_budget, indent)
+                                                 arg.rewrite(&context,
+                                                             multi_line_budget,
+                                                             arg_indent)
                                              })
                                              .collect::<Option<Vec<_>>>());
 

--- a/tests/source/fn-simple.rs
+++ b/tests/source/fn-simple.rs
@@ -24,3 +24,8 @@ pub fn http_fetch_async(listener:Box< AsyncCORSResponseListener+Send >,  script_
 }
 
 fn some_func<T:Box<Trait+Bound>>(val:T){}
+
+fn zzzzzzzzzzzzzzzzzzzz<Type, NodeType>
+                       (selff: Type, mut handle: node::Handle<IdRef<'id, Node<K, V>>, Type, NodeType>)
+                        -> SearchStack<'a, K, V, Type, NodeType>{
+}

--- a/tests/target/fn-simple.rs
+++ b/tests/target/fn-simple.rs
@@ -37,3 +37,10 @@ pub fn http_fetch_async(listener: Box<AsyncCORSResponseListener + Send>,
 
 fn some_func<T: Box<Trait + Bound>>(val: T) {
 }
+
+fn zzzzzzzzzzzzzzzzzzzz<Type, NodeType>(selff: Type,
+                                        mut handle: node::Handle<IdRef<'id, Node<K, V>>,
+                                                                 Type,
+                                                                 NodeType>)
+                                        -> SearchStack<'a, K, V, Type, NodeType> {
+}


### PR DESCRIPTION
This fixes https://github.com/nrc/rustfmt/issues/424.