### PR TITLE
Don't use `visit::walk_*`.  Instead, recurse by hand.

### DIFF
--- a/tests/source/trait.rs
+++ b/tests/source/trait.rs
@@ -1,0 +1,33 @@
+// Test traits
+
+trait Foo {
+    fn bar(x: i32   ) -> Baz<   U> {       Baz::new()
+  }
+
+    fn baz(a: AAAAAAAAAAAAAAAAAAAAAA,
+b: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB)
+-> RetType;
+
+    fn foo(a: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, // Another comment
+b: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB)
+           -> RetType              ; // Some comment
+
+    fn baz(&mut self        ) -> i32          ;
+
+fn increment(&     mut self, x: i32         );
+
+    fn read(&mut self,          x: BufReader<R> /* Used to be MemReader */)
+    where R: Read;
+}
+
+pub trait WriteMessage {
+    fn write_message  (&mut self, &FrontendMessage) ->   io::Result<()>;
+}
+
+trait Runnable {
+    fn handler(self: & Runnable   );
+}
+
+trait TraitWithExpr {
+    fn fn_with_expr(x: [i32;       1]);
+}

--- a/tests/target/impl.rs
+++ b/tests/target/impl.rs
@@ -1,0 +1,3 @@
+// Test impls
+
+impl<T> JSTraceable for SmallVec<[T; 1]> {}

--- a/tests/target/trait.rs
+++ b/tests/target/trait.rs
@@ -25,3 +25,7 @@ pub trait WriteMessage {
 trait Runnable {
     fn handler(self: &Runnable);
 }
+
+trait TraitWithExpr {
+    fn fn_with_expr(x: [i32; 1]);
+}


### PR DESCRIPTION
This is much more straightforward to understand given how rustfmt
rewriting works, and it avoids walking into expressions in unexpected
places.

Fixes #513. Fixes #514.