### PR TITLE
Move to stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 rust:
+ - stable
+ - beta
  - nightly
 
 sudo: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.0.1"
 dependencies = [
  "diff 0.1.7 (git+https://github.com/utkarshkukreti/diff.rs.git)",
  "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -40,6 +41,11 @@ dependencies = [
  "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "getopts"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,8 @@ name = "rustfmt"
 version = "0.0.1"
 dependencies = [
  "diff 0.1.7 (git+https://github.com/utkarshkukreti/diff.rs.git)",
+ "env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "strings 0.0.1 (git+https://github.com/nrc/strings.rs.git)",
@@ -23,6 +25,15 @@ dependencies = [
 name = "diff"
 version = "0.1.7"
 source = "git+https://github.com/utkarshkukreti/diff.rs.git#6edb9454bf4127087aced0fe07ab3ea6894083cb"
+
+[[package]]
+name = "env_logger"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "kernel32-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ dependencies = [
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "strings 0.0.1 (git+https://github.com/nrc/strings.rs.git)",
+ "syntex_syntax 0.18.0 (git+https://github.com/serde-rs/syntex)",
  "term 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -20,6 +21,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bitflags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "diff"
@@ -94,6 +100,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntex_syntax"
+version = "0.18.0"
+source = "git+https://github.com/serde-rs/syntex#176ca5d8add606fac8d503b10c89ddb82f02d92b"
+dependencies = [
+ "bitflags 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "term"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +132,11 @@ dependencies = [
 [[package]]
 name = "unicode-segmentation"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ regex = "0.1.41"
 term = "0.2.11"
 strings = { version = "0.0.1", git = "https://github.com/nrc/strings.rs.git" }
 diff = { git = "https://github.com/utkarshkukreti/diff.rs.git" }
+syntex_syntax = { git = "https://github.com/serde-rs/syntex" }
 log = "0.3.2"
 env_logger = "0.3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,6 @@ diff = { git = "https://github.com/utkarshkukreti/diff.rs.git" }
 syntex_syntax = { git = "https://github.com/serde-rs/syntex" }
 log = "0.3.2"
 env_logger = "0.3.1"
+getopts = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,7 @@ regex = "0.1.41"
 term = "0.2.11"
 strings = { version = "0.0.1", git = "https://github.com/nrc/strings.rs.git" }
 diff = { git = "https://github.com/utkarshkukreti/diff.rs.git" }
+log = "0.3.2"
+env_logger = "0.3.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -3,15 +3,34 @@
 A tool for formatting Rust code according to style guidelines.
 
 ## Gotchas
-* For things you do not want rustfmt to mangle, use
-```rust
- #[rustfmt_skip]
- ```
-* When you run rustfmt use a file called rustfmt.toml to override the default settings of rustfmt.
-* We create a functioning executable called rustfmt in the target directory
+
+* For things you do not want rustfmt to mangle, use one of
+   ```rust
+   #[rustfmt_skip]
+   #[cfg_attr(rustfmt, rustfmt_skip)]
+    ```
+* When you run rustfmt use a file called rustfmt.toml to override the default
+  settings of rustfmt.
+* We create a functioning executable called `rustfmt` in the target directory
+
+## Installation
+
+> **Note:** this method currently requires you to be running a nightly install
+> of Rust as `cargo install` has not yet made its way onto the stable channel.
+
+```
+cargo install --git https://github.com/nrc/rustfmt
+```
+
+or if you're using `multirust`
+
+```
+multirust run nightly cargo install --git https://github.com/nrc/rustfmt
+```
 
 ## How to build and test
-You'll need a pretty up to date version of the **nightly** version of Rust.
+
+First make sure you've got Rust **1.3.0** or greater available, then:
 
 `cargo build` to build.
 

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -15,6 +15,7 @@
 extern crate log;
 extern crate rustfmt;
 extern crate toml;
+extern crate env_logger;
 
 use rustfmt::{WriteMode, run};
 use rustfmt::config::Config;
@@ -71,6 +72,8 @@ fn execute() -> i32 {
 
 fn main() {
     use std::io::Write;
+    let _ = env_logger::init();
+
     let exit_code = execute();
     // Make sure standard output is flushed before we exit
     std::io::stdout().flush().unwrap();

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -15,6 +15,7 @@ extern crate log;
 extern crate rustfmt;
 extern crate toml;
 extern crate env_logger;
+extern crate getopts;
 
 use rustfmt::{WriteMode, run};
 use rustfmt::config::Config;
@@ -23,7 +24,8 @@ use std::env;
 use std::fs::{self, File};
 use std::io::{self, Read};
 use std::path::PathBuf;
-use std::str::FromStr;
+
+use getopts::Options;
 
 // Try to find a project file in the current directory and its parents.
 fn lookup_project_file() -> io::Result<PathBuf> {
@@ -52,7 +54,7 @@ fn lookup_and_read_project_file() -> io::Result<(PathBuf, String)> {
 }
 
 fn execute() -> i32 {
-    let (args, write_mode) = match determine_params(std::env::args()) {
+    let (file, write_mode) = match determine_params(std::env::args().skip(1)) {
         Some(params) => params,
         None => return 1,
     };
@@ -65,7 +67,7 @@ fn execute() -> i32 {
         Err(_) => Default::default(),
     };
 
-    run(args, write_mode, &config);
+    run(&file, write_mode, &config);
     0
 }
 
@@ -83,50 +85,52 @@ fn main() {
     std::process::exit(exit_code);
 }
 
-fn print_usage<S: Into<String>>(reason: S) {
-    println!("{}\n\r usage: rustfmt [-h Help] [--write-mode=[replace|overwrite|display|diff]] \
-              <file_name>",
-             reason.into());
+fn print_usage(opts: &Options, reason: &str) {
+    let reason = format!("{}\nusage: {} [options] <file>",
+                         reason,
+                         env::current_exe().unwrap().display());
+    println!("{}", opts.usage(&reason));
     Config::print_docs();
 }
 
-fn determine_params<I>(args: I) -> Option<(Vec<String>, WriteMode)>
+fn determine_params<I>(args: I) -> Option<(PathBuf, WriteMode)>
     where I: Iterator<Item = String>
 {
-    let arg_prefix = "-";
-    let write_mode_prefix = "--write-mode=";
-    let help_mode = "-h";
-    let long_help_mode = "--help";
-    let mut write_mode = WriteMode::Replace;
-    let mut rustc_args = Vec::new();
+    let mut opts = Options::new();
+    opts.optflag("h", "help", "show this message");
+    opts.optopt("",
+                "write-mode",
+                "mode to write in",
+                "[replace|overwrite|display|diff]");
+    let matches = match opts.parse(args) {
+        Ok(m) => m,
+        Err(e) => {
+            print_usage(&opts, &e.to_string());
+            return None;
+        }
+    };
 
-    // The NewFile option currently isn't supported because it requires another
-    // parameter, but it can be added later.
-    for arg in args {
-        if arg.starts_with(write_mode_prefix) {
-            match FromStr::from_str(&arg[write_mode_prefix.len()..]) {
-                Ok(mode) => write_mode = mode,
-                Err(_) => {
-                    print_usage("Unrecognized write mode");
+    if matches.opt_present("h") {
+        print_usage(&opts, "");
+    }
+
+    let write_mode = match matches.opt_str("write-mode") {
+        Some(mode) => {
+            match mode.parse() {
+                Ok(mode) => mode,
+                Err(..) => {
+                    print_usage(&opts, "Unrecognized write mode");
                     return None;
                 }
             }
-        } else if arg.starts_with(help_mode) || arg.starts_with(long_help_mode) {
-            print_usage("");
-            return None;
-        } else if arg.starts_with(arg_prefix) {
-            print_usage("Invalid argument");
-            return None;
-        } else {
-            // Pass everything else to rustc
-            rustc_args.push(arg);
         }
-    }
+        None => WriteMode::Replace,
+    };
 
-    if rustc_args.len() < 2 {
-        print_usage("Please provide a file to be formatted");
+    if matches.free.len() != 1 {
+        print_usage(&opts, "Please provide one file to format");
         return None;
     }
 
-    Some((rustc_args, write_mode))
+    Some((PathBuf::from(&matches.free[0]), write_mode))
 }

--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -7,8 +7,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-#![feature(path_ext)]
-#![feature(rustc_private)]
+
 #![cfg(not(test))]
 
 #[macro_use]
@@ -21,7 +20,7 @@ use rustfmt::{WriteMode, run};
 use rustfmt::config::Config;
 
 use std::env;
-use std::fs::{File, PathExt};
+use std::fs::{self, File};
 use std::io::{self, Read};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -31,7 +30,7 @@ fn lookup_project_file() -> io::Result<PathBuf> {
     let mut current = try!(env::current_dir());
     loop {
         let config_file = current.join("rustfmt.toml");
-        if config_file.exists() {
+        if fs::metadata(&config_file).is_ok() {
             return Ok(config_file);
         } else {
             current = match current.parent() {

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -72,11 +72,9 @@ pub fn rewrite_chain(mut expr: &ast::Expr,
                                             .collect::<Option<Vec<_>>>());
 
     // Total of all items excluding the last.
-    let almost_total = rewrites.split_last()
-                               .unwrap()
-                               .1
-                               .iter()
-                               .fold(0, |a, b| a + first_line_width(b)) +
+    let almost_total = rewrites[..rewrites.len() - 1]
+                           .iter()
+                           .fold(0, |a, b| a + first_line_width(b)) +
                        parent_rewrite.len();
     let total_width = almost_total + first_line_width(rewrites.last().unwrap());
     let veto_single_line = if context.config.take_source_hints && subexpr_list.len() > 1 {
@@ -95,7 +93,9 @@ pub fn rewrite_chain(mut expr: &ast::Expr,
                            match subexpr_list[0].node {
         ast::Expr_::ExprMethodCall(ref method_name, ref types, ref expressions)
             if context.config.chains_overflow_last => {
-            let (last, init) = rewrites.split_last_mut().unwrap();
+            let len = rewrites.len();
+            let (init, last) = rewrites.split_at_mut(len - 1);
+            let last = &mut last[0];
 
             if init.iter().all(|s| !s.contains('\n')) && total_width <= width {
                 let last_rewrite = width.checked_sub(almost_total)

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -437,7 +437,7 @@ mod test {
     }
 
     #[test]
-    #[rustfmt_skip]
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     fn format_comments() {
         let config = Default::default();
         assert_eq!("/* test */", rewrite_comment(" //test", true, 100, Indent::new(0, 100),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(rustc_private)]
-#![feature(custom_attribute)]
-#![feature(slice_splits)]
-#![feature(slice_patterns)]
-#![feature(catch_panic)]
-#![allow(unused_attributes)]
-
 // TODO we're going to allocate a whole bunch of temp Strings, is it worth
 // keeping some scratch mem for this and running our own StrPool?
 // TODO for lint violations of names, emit a refactor script

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -75,6 +75,9 @@ pub fn last_line_width(s: &str) -> usize {
 fn is_skip(meta_item: &MetaItem) -> bool {
     match meta_item.node {
         MetaItem_::MetaWord(ref s) => *s == SKIP_ANNOTATION,
+        MetaItem_::MetaList(ref s, ref l) => {
+            *s == "cfg_attr" && l.len() == 2 && is_skip(&l[1])
+        }
         _ => false,
     }
 }

--- a/tests/source/macro_not_expr.rs
+++ b/tests/source/macro_not_expr.rs
@@ -1,0 +1,7 @@
+macro_rules! test {
+    ($($t:tt)*) => {}
+}
+
+fn main() {
+    test!( a : B => c d );
+}

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -135,7 +135,6 @@ fn print_mismatches(result: HashMap<String, Vec<Mismatch>>) {
 pub fn idempotent_check(filename: String) -> Result<FormatReport, HashMap<String, Vec<Mismatch>>> {
     let sig_comments = read_significant_comments(&filename);
     let mut config = get_config(sig_comments.get("config").map(|x| &(*x)[..]));
-    let args = vec!["rustfmt".to_owned(), filename];
 
     for (key, val) in &sig_comments {
         if key != "target" && key != "config" {
@@ -146,7 +145,7 @@ pub fn idempotent_check(filename: String) -> Result<FormatReport, HashMap<String
     // Don't generate warnings for to-do items.
     config.report_todo = ReportTactic::Never;
 
-    let mut file_map = format(args, &config);
+    let mut file_map = format(Path::new(&filename), &config);
     let format_report = fmt_lines(&mut file_map, &config);
 
     // Won't panic, as we're not doing any IO.

--- a/tests/target/macro_not_expr.rs
+++ b/tests/target/macro_not_expr.rs
@@ -1,0 +1,7 @@
+macro_rules! test {
+    ($($t:tt)*) => {}
+}
+
+fn main() {
+    test!( a : B => c d );
+}


### PR DESCRIPTION
These commits drop all dependencies on nightly features, primarily:

* `rustc` and `rustc_driver` were dropped as they were just lightly used
* `syntax` was dropped in favor of [`syntex_syntax`](https://crates.io/crates/syntex_syntax)
* `catch_panic` was dropped in favor of spawning a thread an managing the ident interner manually

The business around `catch_panic` is kinda sketchy (and slow in debug mode), but there's a number of benefits to building on stable!

* Stable is stable :)
* rustfmt binaries do not have a dynamic dependence on the compiler
* rustfmt will no longer periodically break due to upstream libsyntax changes
* `cargo install` should "just work" for many more compilers now (e.g. not just nightly ones)

The downsides I can think of are:

* libsyntax will need to be updated manually now. This will rely on the `syntex_syntax` crate being kept in sync with upstream. The upgrade points are at least explicit, however (e.g. in the git history).
* The tests are likely much slower now as libsyntax is not compiled in optimized mode (unlike before where libsyntax on the filesystem is already optimized).
* The business with `thread::spawn` is pretty sketchy in terms of safety, but hopefully this can be mitigated in the future with either a redesign of libsyntax or a stabilization of `panic::recover`.