### PR TITLE
Cleanup

### DIFF
--- a/tests/source/chains-no-overflow.rs
+++ b/tests/source/chains-no-overflow.rs
@@ -23,7 +23,7 @@ fn main() {
                                             .with(|root| {
                                                         *root.borrow_mut()  =   Some(&script_task);
                                                     });
-                                        });                                        
+                                        });
 
     let suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuum = xxxxxxx
         .map(|x| x + 5)

--- a/tests/source/chains.rs
+++ b/tests/source/chains.rs
@@ -43,7 +43,7 @@ fn main() {
                                             .with(|root| {
                                                 *root.borrow_mut()  =   Some(&script_task);
                                             });
-                                        });                                        
+                                        });
 
     let suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuum = xxxxxxx
         .map(|x| x + 5)
@@ -91,13 +91,13 @@ fn floaters() {
         .bar()
         .baz();
 
-    Foo { x: val } .baz(|| { /*force multiline    */    }) .quux(); 
+    Foo { x: val } .baz(|| { /*force multiline    */    }) .quux();
 
     Foo { y: i_am_multi_line, z: ok }
         .baz(|| {
             // force multiline
         })
-        .quux(); 
+        .quux();
 
     a + match x { true => "yay!", false => "boo!" }.bar()
 }

--- a/tests/source/comment.rs
+++ b/tests/source/comment.rs
@@ -33,7 +33,7 @@ fn doc_comment() {
 }
 
 fn chains() {
-                foo.bar(|| { 
+                foo.bar(|| {
                 let x = 10;
                 /* comment */ x })
 }

--- a/tests/source/doc.rs
+++ b/tests/source/doc.rs
@@ -1,3 +1,2 @@
-
 // sadfsdfa
 //sdffsdfasdf

--- a/tests/source/enum.rs
+++ b/tests/source/enum.rs
@@ -2,8 +2,8 @@
 
 #[atrr]
 pub enum Test {
-    A, B(u32, 
-         A /* comment */, 
+    A, B(u32,
+         A /* comment */,
          SomeType),
     /// Doc comment
     C,

--- a/tests/source/extern.rs
+++ b/tests/source/extern.rs
@@ -1,4 +1,3 @@
-
  extern  "C" {
   fn c_func(x: *mut *mut libc::c_void);
 
@@ -12,7 +11,7 @@ pub fn bar() ;
 
 extern {
         fn DMR_GetDevice(pHDev: *mut HDEV, searchMode: DeviceSearchMode, pSearchString: *const c_char, devNr: c_uint, wildcard: c_char) -> TDMR_ERROR;
-        
+
     fn quux() -> (); // Post comment
 }
 
@@ -27,7 +26,7 @@ extern "C" {
 libc::c_long;
         }
 
-   extern    {  
+   extern    {
                        pub fn freopen(filename: *const c_char, mode: *const c_char
                                , mode2: *const c_char
                                , mode3: *const c_char,

--- a/tests/source/fn-custom-2.rs
+++ b/tests/source/fn-custom-2.rs
@@ -23,7 +23,7 @@ fn qux() where X: TTTTTTTTTTTTTTTTTTTTTTTTTTTT, X: TTTTTTTTTTTTTTTTTTTTTTTTTTTT,
 impl Foo {
     fn foo(self, a: Aaaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbbbb, c: Ccccccccccccccccc, d: Ddddddddddddddddddddddddd, e: Eeeeeeeeeeeeeeeeeee) {
         foo();
-    }    
+    }
 
     fn bar<'a: 'bbbbbbbbbbbbbbbbbbbbbbbbbbb, TTTTTTTTTTTTT, UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW>(a: Aaaaaaaaaaaaaaa) {
         bar();

--- a/tests/source/fn-custom-3.rs
+++ b/tests/source/fn-custom-3.rs
@@ -22,7 +22,7 @@ fn qux() where X: TTTTTTTTTTTTTTTTTTTTTTTTTTTT, X: TTTTTTTTTTTTTTTTTTTTTTTTTTTT,
 impl Foo {
     fn foo(self, a: Aaaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbbbb, c: Ccccccccccccccccc, d: Ddddddddddddddddddddddddd, e: Eeeeeeeeeeeeeeeeeee) {
         foo();
-    }    
+    }
 
     fn bar<'a: 'bbbbbbbbbbbbbbbbbbbbbbbbbbb, TTTTTTTTTTTTT, UUUUUUUUUUUUUUUUUUUU: WWWWWWWWWWWWWWWWWWWWWWWW>(a: Aaaaaaaaaaaaaaa) {
         bar();

--- a/tests/source/fn-custom.rs
+++ b/tests/source/fn-custom.rs
@@ -9,5 +9,5 @@ fn foo(a: Aaaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbbbb, c: Ccccccccccccccccc, d: Ddddddd
 impl Foo {
     fn foo(self, a: Aaaaaaaaaaaaaaa, b: Bbbbbbbbbbbbbbbb, c: Ccccccccccccccccc, d: Ddddddddddddddddddddddddd, e: Eeeeeeeeeeeeeeeeeee) {
         foo();
-    }    
+    }
 }

--- a/tests/source/fn-simple.rs
+++ b/tests/source/fn-simple.rs
@@ -1,5 +1,4 @@
-
-fn simple(/*pre-comment on a function!?*/ i: i32/*yes, it's possible!  */   
+fn simple(/*pre-comment on a function!?*/ i: i32/*yes, it's possible!  */
                                         ,response: NoWay /* hose */) {"cool"}
 
 
@@ -15,7 +14,7 @@ fn generic<T>(arg: T) -> &SomeType
         A,
         // Second argument
         B, C, D, /* pre comment */ E /* last comment */) -> &SomeType {
-    arg(a, b, c, d, e)    
+    arg(a, b, c, d, e)
 }
 
 fn foo()  ->  !  {}

--- a/tests/source/hard-tabs.rs
+++ b/tests/source/hard-tabs.rs
@@ -22,7 +22,7 @@ if let (some_very_large, tuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
     } else {
         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa + aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     }
-    
+
 unsafe /* very looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong comment */ {}
 
 unsafe // So this is a very long comment.
@@ -40,7 +40,7 @@ fn generic<T>(arg: T) -> &SomeType
         A,
         // Second argument
         B, C, D, /* pre comment */ E /* last comment */) -> &SomeType {
-    arg(a, b, c, d, e)    
+    arg(a, b, c, d, e)
 }
 
     loong_func().quux(move || {
@@ -61,7 +61,7 @@ fn generic<T>(arg: T) -> &SomeType
     a.b
      .c
      .d();
-    
+
     x().y(|| {
         match cond() {
             true => (),

--- a/tests/source/imports.rs
+++ b/tests/source/imports.rs
@@ -23,10 +23,10 @@ use syntax::some::{};
 mod Foo {
     pub use syntax::ast::{
         ItemForeignMod,
-        ItemImpl, 
+        ItemImpl,
         ItemMac,
         ItemMod,
-        ItemStatic, 
+        ItemStatic,
         ItemDefaultImpl
     };
 

--- a/tests/source/loop.rs
+++ b/tests/source/loop.rs
@@ -1,6 +1,5 @@
-
 fn main() {
-    loop    
+    loop
     {   return some_val;}
 
 let x = loop { do_forever(); };

--- a/tests/source/match.rs
+++ b/tests/source/match.rs
@@ -131,7 +131,7 @@ fn issue339() {
         // }
         // l => {
         //     // comment with ws below
-        //     
+        //
         // }
         m => {
         } n => { } o =>

--- a/tests/source/multiple.rs
+++ b/tests/source/multiple.rs
@@ -110,7 +110,7 @@ fn main() {
                    abcd  abcd abcd abcd abcd abcd abcd abcd abcd abcd \
                     abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd abcd";
            let s = expand(a
-    ,    
+    ,
     b); }
 
 fn deconstruct() -> (SocketAddr, Method, Headers,

--- a/tests/source/nestedmod/mod.rs
+++ b/tests/source/nestedmod/mod.rs
@@ -1,4 +1,3 @@
-
 mod mod2a;
 mod mod2b;
 

--- a/tests/source/nestedmod/mod2b.rs
+++ b/tests/source/nestedmod/mod2b.rs
@@ -1,3 +1,2 @@
-
 #[path="mod2a.rs"]
 mod c;

--- a/tests/source/paths.rs
+++ b/tests/source/paths.rs
@@ -1,4 +1,3 @@
-
 fn main() {
    let constellation_chan = Constellation::<layout::layout_task::LayoutTask,  script::script_task::ScriptTask> ::start(
      compositor_proxy,

--- a/tests/source/single-line-if-else.rs
+++ b/tests/source/single-line-if-else.rs
@@ -26,7 +26,7 @@ fn main() {
         10
     };
 
-    let d   = if  let  Some(val)  =  turbo 
+    let d   = if  let  Some(val)  =  turbo
     { "cool" } else {
      "beans" };
 
@@ -37,7 +37,7 @@ fn main() {
     }
 
     let x = if veeeeeeeeery_loooooong_condition() { aaaaaaaaaaaaaaaaaaaaaaaaaaa } else { bbbbbbbbbb };
-  
+
     let x = if veeeeeeeeery_loooooong_condition()     {    aaaaaaaaaaaaaaaaaaaaaaaaa }   else  {
         bbbbbbbbbb };
 

--- a/tests/source/string-lit.rs
+++ b/tests/source/string-lit.rs
@@ -24,7 +24,7 @@ formatting"#;
 
     let xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx =
         funktion("yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy");
-        
+
     let unicode = "a̐éö̲\r\n";
     let unicode2 = "Löwe 老虎 Léopard";
     let unicode3 = "中华Việt Nam";

--- a/tests/source/struct_lits.rs
+++ b/tests/source/struct_lits.rs
@@ -24,7 +24,7 @@ fn main() {
 
     Quux { x: if cond { bar(); }, y: baz() };
 
-    A { 
+    A {
     // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
     first: item(),
         // Praesent et diam eget libero egestas mattis sit amet vitae augue.
@@ -39,9 +39,9 @@ fn main() {
         decl_id: Some(decl_id),
     }));
 
-    Diagram { /*                 o        This graph demonstrates how                  
-               *                / \       significant whitespace is           
-               *               o   o      preserved.  
+    Diagram { /*                 o        This graph demonstrates how
+               *                / \       significant whitespace is
+               *               o   o      preserved.
                *              /|\   \
                *             o o o   o */
               graph: G, }
@@ -72,13 +72,13 @@ fn issue201_2() {
 fn issue278() {
     let s = S {
         a: 0,
-        //       
+        //
         b: 0,
     };
     let s1 = S {
         a: 0,
         // foo
-        //      
+        //
         // bar
         b: 0,
     };

--- a/tests/source/struct_lits_visual.rs
+++ b/tests/source/struct_lits_visual.rs
@@ -24,7 +24,7 @@ fn main() {
 
     Quux { x: if cond { bar(); }, y: baz() };
 
-    A { 
+    A {
     // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
     first: item(),
         // Praesent et diam eget libero egestas mattis sit amet vitae augue.
@@ -32,9 +32,9 @@ fn main() {
         second: Item
     };
 
-    Diagram { /*                 o        This graph demonstrates how                  
-               *                / \       significant whitespace is           
-               *               o   o      preserved.  
+    Diagram { /*                 o        This graph demonstrates how
+               *                / \       significant whitespace is
+               *               o   o      preserved.
                *              /|\   \
                *             o o o   o */
               graph: G, }

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -1,4 +1,3 @@
-
                                                                        /// A Doc comment
 #[AnAttribute]
 pub struct Foo {
@@ -31,7 +30,7 @@ struct Qux<'a,
 (
     AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA, // Comment
     BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB,
-    #[AnAttr]    
+    #[AnAttr]
     // Comment
     /// Testdoc
     G,
@@ -76,7 +75,7 @@ struct Baz {
 
 
 
-    
+
     d: D
 
 }
@@ -85,7 +84,7 @@ struct Baz
 {
     // Comment A
     a: A,
-    
+
     // Comment B
 b: B,
     // Comment C

--- a/tests/target/doc.rs
+++ b/tests/target/doc.rs
@@ -1,3 +1,2 @@
-
 // sadfsdfa
 // sdffsdfasdf

--- a/tests/target/extern.rs
+++ b/tests/target/extern.rs
@@ -1,4 +1,3 @@
-
 extern {
     fn c_func(x: *mut *mut libc::c_void);
 

--- a/tests/target/fn-simple.rs
+++ b/tests/target/fn-simple.rs
@@ -1,4 +1,3 @@
-
 fn simple(// pre-comment on a function!?
           i: i32, // yes, it's possible!
           response: NoWay /* hose */) {

--- a/tests/target/loop.rs
+++ b/tests/target/loop.rs
@@ -1,4 +1,3 @@
-
 fn main() {
     loop {
         return some_val;

--- a/tests/target/nestedmod/mod.rs
+++ b/tests/target/nestedmod/mod.rs
@@ -1,4 +1,3 @@
-
 mod mod2a;
 mod mod2b;
 

--- a/tests/target/nestedmod/mod2b.rs
+++ b/tests/target/nestedmod/mod2b.rs
@@ -1,3 +1,2 @@
-
 #[path="mod2a.rs"]
 mod c;

--- a/tests/target/paths.rs
+++ b/tests/target/paths.rs
@@ -1,4 +1,3 @@
-
 fn main() {
     let constellation_chan =
         Constellation::<layout::layout_task::LayoutTask,

--- a/tests/target/structs.rs
+++ b/tests/target/structs.rs
@@ -1,4 +1,3 @@
-
 /// A Doc comment
 #[AnAttribute]
 pub struct Foo {


### PR DESCRIPTION
Whitespace: remove leading newlines; replace lines containing only whitespace with empty lines; replace multiple trailing newlines with a single newline; remove trailing whitespace in lines.

Images: Compress PNG files with zopflipng, JPG files with mozjpeg jpegtran, and GIF files with gifsicle, all losslessly.

This PR was created semiautomatically.