### PR TITLE
Fix crash speculatively parsing macro arguments as expressions.

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -422,7 +422,7 @@ impl Rewrite for ast::Block {
             return Some(user_str);
         }
 
-        let mut visitor = FmtVisitor::from_codemap(context.codemap, context.config, None);
+        let mut visitor = FmtVisitor::from_codemap(context.parse_session, context.config, None);
         visitor.block_indent = context.block_indent;
 
         let prefix = match self.rules {
@@ -833,7 +833,9 @@ impl Rewrite for ast::Arm {
         let attr_str = if !attrs.is_empty() {
             // We only use this visitor for the attributes, should we use it for
             // more?
-            let mut attr_visitor = FmtVisitor::from_codemap(context.codemap, context.config, None);
+            let mut attr_visitor = FmtVisitor::from_codemap(context.parse_session,
+                                                            context.config,
+                                                            None);
             attr_visitor.block_indent = context.block_indent;
             attr_visitor.last_pos = attrs[0].span.lo;
             if attr_visitor.visit_attrs(attrs) {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -21,7 +21,7 @@
 
 use syntax::ast;
 use syntax::parse::token::{Eof, Comma, Token};
-use syntax::parse::{ParseSess, tts_to_parser};
+use syntax::parse::tts_to_parser;
 use syntax::codemap::{mk_sp, BytePos};
 
 use Indent;
@@ -73,8 +73,7 @@ pub fn rewrite_macro(mac: &ast::Mac,
         };
     }
 
-    let parse_session = ParseSess::new();
-    let mut parser = tts_to_parser(&parse_session, mac.node.tts.clone(), Vec::new());
+    let mut parser = tts_to_parser(context.parse_session, mac.node.tts.clone(), Vec::new());
     let mut expr_vec = Vec::new();
 
     loop {

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -11,6 +11,7 @@
 // A generic trait to abstract the rewriting of an element (of the AST).
 
 use syntax::codemap::{CodeMap, Span};
+use syntax::parse::ParseSess;
 
 use Indent;
 use config::Config;
@@ -27,6 +28,7 @@ pub trait Rewrite {
 }
 
 pub struct RewriteContext<'a> {
+    pub parse_session: &'a ParseSess,
     pub codemap: &'a CodeMap,
     pub config: &'a Config,
     // Indentation due to nesting of blocks.
@@ -36,6 +38,7 @@ pub struct RewriteContext<'a> {
 impl<'a> RewriteContext<'a> {
     pub fn nested_context(&self) -> RewriteContext<'a> {
         RewriteContext {
+            parse_session: self.parse_session,
             codemap: self.codemap,
             config: self.config,
             block_indent: self.block_indent.block_indent(self.config),

--- a/tests/source/macros.rs
+++ b/tests/source/macros.rs
@@ -27,4 +27,6 @@ fn main() {
     hamkaas!{ () };
 
     macrowithbraces! {dont,    format, me}
+
+    x!(fn);
 }

--- a/tests/target/macros.rs
+++ b/tests/target/macros.rs
@@ -30,4 +30,6 @@ fn main() {
     hamkaas!{ () };
 
     macrowithbraces! {dont,    format, me}
+
+    x!(fn);
 }


### PR DESCRIPTION
The problem is essentially that if we try to parse a token tree using a
CodeMap different from the one the tree was originally parsed with,
spans become nonsense. Since CodeMaps can't be cloned, we're basically
forced to use the original ParseSess for additional parsing.

Ideally, rustfmt would be a bit more clever and figure out how to parse
macro arguments based on the definition of the macro itself, rather than
just guessing that a particular token sequence looks like an expression,
but this is good enough for now.

Fixes #538.