### PR TITLE
Stdin support

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -77,8 +77,8 @@ fn execute() -> i32 {
     opts.optflag("h", "help", "show this message");
     opts.optopt("",
                 "write-mode",
-                "mode to write in",
-                "[replace|overwrite|display|plain|diff|coverage]");
+                "mode to write in (not usable when piping from stdin)",
+                "[replace|overwrite|display|diff|coverage]");
 
     let operation = determine_operation(&opts, env::args().skip(1));
 
@@ -153,21 +153,7 @@ fn determine_operation<I>(opts: &Options, args: I) -> Operation
     }
 
     // if no file argument is supplied, read from stdin
-    if matches.free.len() != 1 {
-
-        // make sure the write mode is plain or not set
-        // (the other options would require a file)
-        match matches.opt_str("write-mode") {
-            Some(mode) => {
-                match mode.parse() {
-                    Ok(WriteMode::Plain) => (),
-                    _ => return Operation::InvalidInput("Using stdin requires write-mode to be \
-                                                         plain"
-                                                            .into()),
-                }
-            }
-            _ => (),
-        }
+    if matches.free.len() == 0 {
 
         let mut buffer = String::new();
         match io::stdin().read_to_string(&mut buffer) {
@@ -175,6 +161,7 @@ fn determine_operation<I>(opts: &Options, args: I) -> Operation
             Err(e) => return Operation::InvalidInput(e.to_string()),
         }
 
+        // WriteMode is always plain for Stdin
         return Operation::Stdin(buffer, WriteMode::Plain);
     }
 

--- a/src/filemap.rs
+++ b/src/filemap.rs
@@ -102,14 +102,14 @@ pub fn write_file(text: &StringBuffer,
         }
         WriteMode::Plain => {
             let stdout = stdout();
-            let stdout_lock = stdout.lock();
-            try!(write_system_newlines(stdout_lock, text, config));
+            let stdout = stdout.lock();
+            try!(write_system_newlines(stdout, text, config));
         }
         WriteMode::Display | WriteMode::Coverage => {
             println!("{}:\n", filename);
             let stdout = stdout();
-            let stdout_lock = stdout.lock();
-            try!(write_system_newlines(stdout_lock, text, config));
+            let stdout = stdout.lock();
+            try!(write_system_newlines(stdout, text, config));
         }
         WriteMode::Diff => {
             println!("Diff of {}:\n", filename);

--- a/src/filemap.rs
+++ b/src/filemap.rs
@@ -46,11 +46,11 @@ pub fn write_all_files(file_map: &FileMap,
     Ok(result)
 }
 
-fn write_file(text: &StringBuffer,
-              filename: &str,
-              mode: WriteMode,
-              config: &Config)
-              -> Result<Option<String>, io::Error> {
+pub fn write_file(text: &StringBuffer,
+                  filename: &str,
+                  mode: WriteMode,
+                  config: &Config)
+                  -> Result<Option<String>, io::Error> {
 
     // prints all newlines either as `\n` or as `\r\n`
     fn write_system_newlines<T>(mut writer: T,
@@ -99,6 +99,11 @@ fn write_file(text: &StringBuffer,
             let filename = filename.to_owned() + "." + extn;
             let file = try!(File::create(&filename));
             try!(write_system_newlines(file, text, config));
+        }
+        WriteMode::Plain => {
+            let stdout = stdout();
+            let stdout_lock = stdout.lock();
+            try!(write_system_newlines(stdout_lock, text, config));
         }
         WriteMode::Display | WriteMode::Coverage => {
             println!("{}:\n", filename);


### PR DESCRIPTION
I was trying to get rustfmt work with https://github.com/Chiel92/vim-autoformat and found to my surprise that there seems to be no support for receiving a string on stdin and outputting a simple formatting to stdout.

This is actually the default behavior of most formatting tools, like `gofmt`, and really vital for IDE and tooling integration. I'm sorry if I'm misunderstanding something and rustfmt already supports it somehow. Feel free to close in that case!

Most of the existing code seems to be built with a multiple-file codemap in mind, making it hard to whip up a perfect solution in trivial time. My approach is trying to get the job done without breaking existing behavior.

tl;dr
- `rustfmt` will now read from stdin if no file was specified and format that code without walking any other files
- a new write-mode `plain` was introduced to print to stdout without any fluff