### PR TITLE
fix unused variable `path` warning

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -94,7 +94,7 @@ fn execute() -> i32 {
         Operation::Stdin(input, write_mode) => {
             // try to read config from local directory
             let config = match lookup_and_read_project_file(&Path::new(".")) {
-                Ok((path, toml)) => {
+                Ok((_, toml)) => {
                     Config::from_toml(&toml)
                 }
                 Err(_) => Default::default(),


### PR DESCRIPTION
remove following warning

```
src/bin/rustfmt.rs:97:21: 97:25 warning: unused variable: `path`, #[warn(unused_variables)] on by default
src/bin/rustfmt.rs:97                 Ok((path, toml)) => {
                                          ^~~~
```