### PR TITLE
Don't strip semi-colons from expressions with non-void type since it …

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -507,12 +507,8 @@ fn semicolon_for_stmt(stmt: &ast::Stmt) -> bool {
             match expr.node {
                 ast::Expr_::ExprWhile(..) |
                 ast::Expr_::ExprWhileLet(..) |
-                ast::Expr_::ExprIf(..) |
-                ast::Expr_::ExprIfLet(..) |
-                ast::Expr_::ExprBlock(..) |
                 ast::Expr_::ExprLoop(..) |
-                ast::Expr_::ExprForLoop(..) |
-                ast::Expr_::ExprMatch(..) => false,
+                ast::Expr_::ExprForLoop(..) => false,
                 _ => true,
             }
         }

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -40,7 +40,7 @@ fn foo() -> bool {
         result
     } else {
         4
-    }
+    };
 
     if let Some(x) = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa {
         // Nothing
@@ -253,5 +253,5 @@ fn repeats() {
 fn blocks() {
     if 1 + 1 == 2 {
         println!("yay arithmetix!");
-    }
+    };
 }

--- a/tests/target/match.rs
+++ b/tests/target/match.rs
@@ -228,7 +228,7 @@ fn issue383() {
     match resolution.last_private {
         LastImport{..} => false,
         _ => true,
-    }
+    };
 }
 
 fn issue507() {


### PR DESCRIPTION
…can change semantics

Closes #542