### PR TITLE
Option to disable line breaking in comments

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -81,7 +81,7 @@ pub fn rewrite_comment(orig: &str,
             result.push_str(line_start);
         }
 
-        if line.len() > max_chars {
+        if config.wrap_comments && line.len() > max_chars {
             let rewrite = try_opt!(rewrite_string(line, &fmt));
             result.push_str(&rewrite);
         } else {
@@ -439,7 +439,8 @@ mod test {
     #[test]
     #[cfg_attr(rustfmt, rustfmt_skip)]
     fn format_comments() {
-        let config = Default::default();
+        let mut config: ::config::Config = Default::default();
+        config.wrap_comments = true;
         assert_eq!("/* test */", rewrite_comment(" //test", true, 100, Indent::new(0, 100),
                                                  &config).unwrap());
         assert_eq!("// comment\n// on a", rewrite_comment("// comment on a", false, 10,

--- a/src/config.rs
+++ b/src/config.rs
@@ -294,11 +294,11 @@ create_config! {
     report_fixme: ReportTactic, ReportTactic::Never,
         "Report all, none or unnumbered occurrences of FIXME in source file comments";
     chain_base_indent: BlockIndentStyle, BlockIndentStyle::Visual, "Indent on chain base";
-    // Alphabetically, case sensitive.
     reorder_imports: bool, false, "Reorder import statements alphabetically";
     single_line_if_else: bool, false, "Put else on same line as closing brace for if statements";
     format_strings: bool, true, "Format string literals, or leave as is";
     chains_overflow_last: bool, true, "Allow last call in method chain to break the line";
     take_source_hints: bool, true, "Retain some formatting characteristics from the source code";
     hard_tabs: bool, false, "Use tab characters for indentation, spaces for alignment";
+    wrap_comments: bool, false, "Break comments to fit on the line";
 }

--- a/tests/source/attrib.rs
+++ b/tests/source/attrib.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // Test attributes and doc comments are preserved.
 
 /// Blah blah blah.

--- a/tests/source/comment.rs
+++ b/tests/source/comment.rs
@@ -1,3 +1,5 @@
+// rustfmt-wrap_comments: true
+
 //! Doc comment
 fn test() {
 // comment

--- a/tests/source/comment2.rs
+++ b/tests/source/comment2.rs
@@ -1,2 +1,4 @@
+// rustfmt-wrap_comments: true
+
 /// This is a long line that angers rustfmt. Rustfmt shall deal with it swiftly and justly.
 pub mod foo {}

--- a/tests/source/comment3.rs
+++ b/tests/source/comment3.rs
@@ -1,3 +1,5 @@
+// rustfmt-wrap_comments: true
+
 //! This is a long line that angers rustfmt. Rustfmt shall deal with it swiftly and justly.
 
 pub mod foo {}

--- a/tests/source/enum.rs
+++ b/tests/source/enum.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // Enums test
 
 #[atrr]

--- a/tests/source/expr.rs
+++ b/tests/source/expr.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // Test expressions
 
 fn foo() -> bool {

--- a/tests/source/hard-tabs.rs
+++ b/tests/source/hard-tabs.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // rustfmt-hard_tabs: true
 
 fn main() {

--- a/tests/source/multiple.rs
+++ b/tests/source/multiple.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // Test of lots of random stuff.
 // FIXME split this into multiple, self-contained tests.
 

--- a/tests/source/struct_lits.rs
+++ b/tests/source/struct_lits.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // Struct literal expressions.
 
 fn main() {

--- a/tests/source/struct_lits_multiline.rs
+++ b/tests/source/struct_lits_multiline.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // rustfmt-struct_lit_multiline_style: ForceMulti
 
 // Struct literal expressions.

--- a/tests/source/struct_lits_visual.rs
+++ b/tests/source/struct_lits_visual.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // rustfmt-struct_lit_style: Visual
 
 // Struct literal expressions.

--- a/tests/source/struct_lits_visual_multiline.rs
+++ b/tests/source/struct_lits_visual_multiline.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // rustfmt-struct_lit_style: Visual
 // rustfmt-struct_lit_multiline_style: ForceMulti
 

--- a/tests/source/structs.rs
+++ b/tests/source/structs.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 
                                                                        /// A Doc comment
 #[AnAttribute]

--- a/tests/target/attrib.rs
+++ b/tests/target/attrib.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // Test attributes and doc comments are preserved.
 
 /// Blah blah blah.

--- a/tests/target/comment.rs
+++ b/tests/target/comment.rs
@@ -1,3 +1,5 @@
+// rustfmt-wrap_comments: true
+
 //! Doc comment
 fn test() {
     // comment

--- a/tests/target/comment2.rs
+++ b/tests/target/comment2.rs
@@ -1,3 +1,5 @@
+// rustfmt-wrap_comments: true
+
 /// This is a long line that angers rustfmt. Rustfmt shall deal with it swiftly
 /// and justly.
 pub mod foo {

--- a/tests/target/comment3.rs
+++ b/tests/target/comment3.rs
@@ -1,3 +1,5 @@
+// rustfmt-wrap_comments: true
+
 //! This is a long line that angers rustfmt. Rustfmt shall deal with it swiftly
 //! and justly.
 

--- a/tests/target/enum.rs
+++ b/tests/target/enum.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // Enums test
 
 #[atrr]

--- a/tests/target/expr.rs
+++ b/tests/target/expr.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // Test expressions
 
 fn foo() -> bool {

--- a/tests/target/hard-tabs.rs
+++ b/tests/target/hard-tabs.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // rustfmt-hard_tabs: true
 
 fn main() {

--- a/tests/target/multiple.rs
+++ b/tests/target/multiple.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // Test of lots of random stuff.
 // FIXME split this into multiple, self-contained tests.
 

--- a/tests/target/struct_lits.rs
+++ b/tests/target/struct_lits.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // Struct literal expressions.
 
 fn main() {

--- a/tests/target/struct_lits_multiline.rs
+++ b/tests/target/struct_lits_multiline.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // rustfmt-struct_lit_multiline_style: ForceMulti
 
 // Struct literal expressions.

--- a/tests/target/struct_lits_visual.rs
+++ b/tests/target/struct_lits_visual.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // rustfmt-struct_lit_style: Visual
 
 // Struct literal expressions.

--- a/tests/target/struct_lits_visual_multiline.rs
+++ b/tests/target/struct_lits_visual_multiline.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 // rustfmt-struct_lit_style: Visual
 // rustfmt-struct_lit_multiline_style: ForceMulti
 

--- a/tests/target/structs.rs
+++ b/tests/target/structs.rs
@@ -1,3 +1,4 @@
+// rustfmt-wrap_comments: true
 
 /// A Doc comment
 #[AnAttribute]


### PR DESCRIPTION
Set to false by default for now, since we are having a lot of problems with comments. We should set to true once we have a better algorithm.