### PR TITLE
Check if the CWD contains a config (previously it only checked parents)

### DIFF
--- a/src/bin/rustfmt.rs
+++ b/src/bin/rustfmt.rs
@@ -54,13 +54,14 @@ fn lookup_project_file(input_file: &Path) -> io::Result<PathBuf> {
     // current = try!(fs::canonicalize(current));
 
     loop {
-        // If the current directory has no parent, we're done searching.
-        if !current.pop() {
-            return Err(io::Error::new(io::ErrorKind::NotFound, "Config not found"));
-        }
         let config_file = current.join("rustfmt.toml");
         if fs::metadata(&config_file).is_ok() {
             return Ok(config_file);
+        }
+
+        // If the current directory has no parent, we're done searching.
+        if !current.pop() {
+            return Err(io::Error::new(io::ErrorKind::NotFound, "Config not found"));
         }
     }
 }


### PR DESCRIPTION
Was kinda surprised to see my config file being ignored when I ran rustfmt from the project root directory, which is where I keep my rustfmt.toml.